### PR TITLE
support intl number login

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -36,9 +36,9 @@ $(function() {
 
         platform = sdk.platform();
 
-        // TODO: Improve later to support international phone number country codes
+        // TODO: Improve later to support international phone number country codes better
         if (login) {
-            login = (login.match(/^\+?1/)) ? login : '1' + login;
+            login = (login.match(/^[\+1]/)) ? login : '1' + login;
             login = login.replace(/\W/g, '')
         }
 


### PR DESCRIPTION
Update demo login phone number modifier to support international, non-1 country code, numbers. The update avoids prefixing the number with a `1` when encountering any number starting with a `+`, e.g. `+44` for UK.