### PR TITLE
Replace invalid setting iceGatheringTimeout with iceCheckingTimeout

### DIFF
--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -139,7 +139,7 @@
             domain: this.sipInfo.domain,
             autostart: true,
             register: true,
-            iceGatheringTimeout: this.sipInfo.iceGatheringTimeout || 3000
+            iceCheckingTimeout: this.sipInfo.iceCheckingTimeout || 3000
         };
 
         this.appKey = options.appKey;


### PR DESCRIPTION
Currently it is not possible to configure a timeout for ice gathering procedure because invalid iceGatheringTimeout setting is passed to sip.js. This should be replaced with valid one: iceCheckingTimeout.