### PR TITLE
Fix README.md anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The RingCentral WebPhone Library includes a JavaScript WebRTC library and a WebR
   1. [Flip](#flip)
   1. [Transfer](#transfer)
   1. [Forward](#forward)
-  1. [Start Stop Recording](#start-stop-recording)
+  1. [Start/Stop Recording](#startstop-recording)
   1. [Barge/Whisper](#bargewhisper)
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The RingCentral WebPhone Library includes a JavaScript WebRTC library and a WebR
   1. [Transfer](#transfer)
   1. [Forward](#forward)
   1. [Start Stop Recording](#start-stop-recording)
-  1. [Barge Whisper](barge-whisper)
+  1. [Barge/Whisper](#barge/whisper)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The RingCentral WebPhone Library includes a JavaScript WebRTC library and a WebR
   1. [Transfer](#transfer)
   1. [Forward](#forward)
   1. [Start Stop Recording](#start-stop-recording)
-  1. [Barge/Whisper](#barge/whisper)
+  1. [Barge/Whisper](#bargewhisper)
 
 ---
 


### PR DESCRIPTION
Fix anchors when `/` is present in Markdown heading.