### PR TITLE
Fixing the rtcp Mutex Policy issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bower install ringcentral-web-phone
 
 ### If you are not using Bower or NPM:
 
-1. Download SIP.JS: [http://sipjs.com/download/sip-0.7.5.js](http://sipjs.com/download/sip-0.7.5.js)
+1. Download SIP.JS: [http://sipjs.com/download/sip-0.7.7.js](http://sipjs.com/download/sip-0.7.7.js)
 2. Download WebPhone SDK: [https://cdn.rawgit.com/ringcentral/ringcentral-web-phone/master/src/ringcentral-web-phone.js](https://cdn.rawgit.com/ringcentral/ringcentral-web-phone/master/src/ringcentral-web-phone.js)
 3. Download audio files:
     1. [https://cdn.rawgit.com/ringcentral/ringcentral-web-phone/master/audio/incoming.ogg](https://cdn.rawgit.com/ringcentral/ringcentral-web-phone/master/audio/incoming.ogg)

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
   ],
   "dependencies": {
     "ringcentral": "^2.0.5",
-    "sip.js": "^0.7.6"
+    "sip.js": "^0.7.7"
   },
   "devDependencies": {
     "jquery": "^2.2.1",

--- a/demo/index.html
+++ b/demo/index.html
@@ -204,8 +204,8 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/bootstrap/3.3.7/js/bootstrap.js"></script>
 <script type="text/javascript" src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
 <script type="text/javascript" src="//cdn.jsdelivr.net/es6-promise/3.1.2/es6-promise.js"></script>
-<script type="text/javascript" src="//cdn.pubnub.com/pubnub-3.15.2.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/onsip/SIP.js/0.7.6/dist/sip-0.7.6.js"></script>
+<script type="text/javascript" src="//cdn.pubnub.com/sdk/javascript/pubnub.4.4.2.js"></script>
+<script type="text/javascript" src="//cdn.rawgit.com/onsip/SIP.js/0.7.7/dist/sip-0.7.7.js"></script>
 <script type="text/javascript" src="//cdn.rawgit.com/ringcentral/ringcentral-js/master/build/ringcentral.js"></script>
 <script type="text/javascript" src="../src/ringcentral-web-phone.js"></script>
 <script type="text/javascript" src="index.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
         ],
 
         files: [
-            'http://cdn.rawgit.com/onsip/SIP.js/0.7.5/dist/sip-0.7.6.js', //FIXME We use CDN because SIP.JS NPM does not have build version
+            'http://cdn.rawgit.com/onsip/SIP.js/0.7.7/dist/sip-0.7.7.js', //FIXME We use CDN because SIP.JS NPM does not have build version
             require.resolve('es6-promise/dist/es6-promise.auto'),
             require.resolve('pubnub/modern/dist/pubnub'),
             require.resolve('whatwg-fetch'),

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "./node_modules/.bin/http-server"
   },
   "dependencies": {
-    "sip.js": "^0.7.6"
+    "sip.js": "^0.7.7"
   },
   "devDependencies": {
     "bower": "1.7.7",

--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -160,7 +160,8 @@
             autostart: true,
             register: true,
             iceCheckingTimeout: this.sipInfo.iceCheckingTimeout || this.sipInfo.iceGatheringTimeout || 500,
-            mediaHandlerFactory: rcMediaHandlerFactory
+            mediaHandlerFactory: rcMediaHandlerFactory,
+            rtcpMuxPolicy : "negotiate"
         };
 
         this.appKey = options.appKey;


### PR DESCRIPTION
Adding rtcpMuxPolicy : "negotiate"  . Fixes rtcpMuxPolicy issue. 
Updated the Sip.js library to 0.7.7

rtcpMuxPolicy
The RTCP mux policy to use when gathering ICE candidates, in order to support non-multiplexed RTCP. The value must be one of those from the RTCRtcpMuxPolicy enum. The default is "require".
We are setting it to "negotiate"

Related links:
https://bugs.chromium.org/p/webrtc/issues/detail?id=6030
https://www.chromestatus.com/feature/5654810086866944