### PR TITLE
autoregister lost extraheaders

### DIFF
--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -221,7 +221,7 @@
             },
             domain: this.sipInfo.domain,
             autostart: false,
-            register: true,
+            register: false,
             userAgentString: userAgentString,
             sessionDescriptionHandlerFactoryOptions: sessionDescriptionHandlerFactoryOptions,
             sessionDescriptionHandlerFactory : sessionDescriptionHandlerFactory
@@ -273,6 +273,7 @@
         this.userAgent._onMessage = this.userAgent.onTransportReceiveMsg;
         this.userAgent.onTransportReceiveMsg = onMessage.bind(this.userAgent);
         this.userAgent.start();
+	this.userAgent.register();
     }
 
     /*--------------------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
SIP autoregiser (register === true in the UA options) using internal register command, so extra headers are lost. 
Use manual register to pickup extraheaders