### PR TITLE
fixed NaN for NLR calculation

### DIFF
--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -1186,12 +1186,12 @@
     }
 
     function calculateStats(qosStatsObj) {
-        var rawNLR = (qosStatsObj.packetLost * 100) / (qosStatsObj.packetsReceived + qosStatsObj.packetLost);
+        var rawNLR = (qosStatsObj.packetLost * 100) / (qosStatsObj.packetsReceived + qosStatsObj.packetLost) || 0;
         var rawJBN =
             qosStatsObj.totalIntervalCount > 0 ? qosStatsObj.totalSumJitter / qosStatsObj.totalIntervalCount : 0;
 
         return Object.assign({}, qosStatsObj, {
-            NLR: parseFloat(rawNLR).toFixed(2) || 0,
+            NLR: parseFloat(rawNLR).toFixed(2),
             //JitterBufferNominal
             JBN: parseFloat(rawJBN).toFixed(2),
             //JitterBufferDiscardRate


### PR DESCRIPTION
NaN.toFixed() returns string 'NaN' so 
parseFloat(rawNLR).toFixed(2) || 0 
doesn't work as expected