### PR TITLE
Upgrading SDK to v0.7.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ session.stopRecord().then(...);
 
 Not yet implemented. Could be done by dialing \*83. The account should be enabled for barge/whisper access through system admin.
 
-## Upgrade Procedure from v0.4.X to 0.7.6
+## Upgrade Procedure from v0.4.X to 0.7.7
 
 - SDK now only supports only Unified SDP plan. You can find more information about this here:  [https://chromestatus.com/feature/5723303167655936](https://chromestatus.com/feature/5723303167655936) 
 
@@ -360,6 +360,7 @@ Not yet implemented. Could be done by dialing \*83. The account should be enable
 
 - SDK can now detect AudioOutputLevel if the headset/speaker device is not configured correctly or the output volume is set to 0. Added event listner `no-output-volume` for the same
 
+- You can now enable logging for AudioInputLevel, AudioOutputLevel and Media Reports by setting the custom UA configuration option `options.enableMediaReportLogging` to true. This will help in providing more information on one-way audio issues if there are any
 
 ### Initialization
 
@@ -395,7 +396,8 @@ webPhone = new RingCentral.WebPhone(data, {
         local: localVideoElement
     },
     //to enable QoS Analytics Feature  
-    enableQos:true
+    enableQos:true,
+    enableMediaReportLogging : true
 });
 ```
 
@@ -475,3 +477,4 @@ var session = webPhone.userAgent.invite(number, {
 | Nov 2019 | 0.7.3 | 0.13.5 | 71+ | 62 to 65 , :warning: QoS feature not supported |
 | Nov 2019 | 0.7.5 | 0.13.5 | 71+ | 62 to 65 , :warning: QoS feature not supported |
 | Jan 2020 | 0.7.6 | 0.13.5 | 71+ | 62 to 65 , :warning: QoS feature not supported |
+| Jan 2020 | 0.7.7 | 0.13.5 | 71+ | 62 to 65 , :warning: QoS feature not supported |

--- a/demo/index.js
+++ b/demo/index.js
@@ -150,7 +150,8 @@ $(function() {
                 remote: remoteVideoElement,
                 local: localVideoElement
             },
-            enableQos: true
+            enableQos: true,
+            enableMediaReportLogging: true
         });
 
         webPhone.userAgent.audioHelper.loadAudio({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ringcentral-web-phone",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "scripts": {
     "test": "npm run test:ut && npm run test:e2e",
     "test:coverage": "cat .coverage/lcov.info | coveralls -v",

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export interface WebPhoneOptions {
     enableUnifiedSDP?: boolean;
     enableMidLinesInSDP?: boolean;
     enableQos?: boolean;
+    enableMediaReportLogging?:boolean;
     onSession?: (session: WebPhoneSession) => any;
     audioHelper?: AudioHelperOptions;
     modifiers?: SessionDescriptionHandlerModifiers;
@@ -46,7 +47,7 @@ export interface WebPhoneOptions {
 }
 
 export default class WebPhone {
-    public static version = '0.7.6';
+    public static version = '0.7.7';
     public static uuid = uuid;
     public static delay = delay;
     public static extend = extend;

--- a/src/qos.ts
+++ b/src/qos.ts
@@ -32,7 +32,7 @@ export const startQosStatsCollection = (session: WebPhoneSession): void => {
                 if (item.type === 'remotecandidate') {
                     qosStatsObj.remotecandidate = item;
                 }
-                if (item.type === 'ssrc' && item.id.includes('send')) {
+                if (item.type === 'ssrc' && item.id.includes('send') && session.ua.enableMediaReportLogging) {
                     if (parseInt(item.audioInputLevel, 10) === 0) {
                         session.logger.log(
                             'AudioInputLevel is 0. The local track might be muted or could have potential one-way audio issue. Check Microphone Volume settings.'
@@ -48,11 +48,13 @@ export const startQosStatsCollection = (session: WebPhoneSession): void => {
                     qosStatsObj.totalIntervalCount += 1;
                     qosStatsObj.JBM = Math.max(qosStatsObj.JBM, parseFloat(item.googJitterBufferMs));
                     qosStatsObj.netType = addToMap(qosStatsObj.netType, network);
-                    if (parseInt(item.audioOutputLevel, 10) <= 1) {
-                        session.logger.log(
-                            'Remote audioOutput level is 1. The remote track might be muted or could have potential one-way audio issue'
-                        );
-                        session.emit('no-output-volume');
+                    if(session.ua.enableMediaReportLogging) {
+                        if (parseInt(item.audioOutputLevel, 10) <= 1) {
+                            session.logger.log(
+                                'Remote audioOutput level is 1. The remote track might be muted or could have potential one-way audio issue'
+                            );
+                            session.emit('no-output-volume');
+                        }
                     }
                 }
             });

--- a/src/session.ts
+++ b/src/session.ts
@@ -568,7 +568,7 @@ async function warmTransfer(
 
 async function transfer(this: WebPhoneSession, target: WebPhoneSession, options): Promise<ReferClientContext> {
     await (this.localHold ? Promise.resolve(null) : this.hold());
-    await delay(300);
+    await delay(600);
     return this.blindTransfer(target, options);
 }
 
@@ -730,7 +730,9 @@ function addTrack(this: WebPhoneSession, remoteAudioEle, localAudioEle): void {
         this.logger.log('Start gathering media report');
         this.mediaStatsStarted = true;
         this.mediaStreams.getMediaStats((report: RTPReport) => {
-            this.logger.log(`Got media report: ${JSON.stringify(report)}`);
+            if(this.ua.enableMediaReportLogging) {
+                this.logger.log(`Got media report: ${JSON.stringify(report)}`);
+            }
             if (!this.reinviteForNoAudioSent && isNoAudio(report)) {
                 this.logger.log('No audio report');
                 this.noAudioReportCount++;

--- a/src/userAgent.ts
+++ b/src/userAgent.ts
@@ -7,6 +7,7 @@ export interface WebPhoneUserAgent extends UA {
     media: any;
     defaultHeaders: any;
     enableQos: boolean;
+    enableMediaReportLogging:boolean;
     qosCollectInterval: number;
     sipInfo: any;
     audioHelper: AudioHelper;
@@ -29,6 +30,7 @@ export const patchUserAgent = (userAgent: WebPhoneUserAgent, sipInfo, options, i
     userAgent.media = {};
 
     userAgent.enableQos = options.enableQos;
+    userAgent.enableMediaReportLogging = options.enableMediaReportLogging;
 
     userAgent.qosCollectInterval = options.qosCollectInterval || 5000;
 


### PR DESCRIPTION
1. Introducing enableMediaReportLogging flag . This will help in customizing the logging for investigating oneway audio issue and avoid polluting the logs when not necessary
2. Increasing the delay between putting call on hold and sending refer on 'Transfer' to 600ms. This is to solve failed transfers that are caused on clients with poor network connection .

Closes #262 