### PR TITLE
Fix for race condition between INVITE and REFER on blind transfer

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -567,8 +567,6 @@ async function warmTransfer(
 /*--------------------------------------------------------------------------------------------------------------------*/
 
 async function transfer(this: WebPhoneSession, target: WebPhoneSession, options): Promise<ReferClientContext> {
-    await (this.localHold ? Promise.resolve(null) : this.hold());
-    await delay(600);
     return this.blindTransfer(target, options);
 }
 


### PR DESCRIPTION
This is fix for #259 
Hold is not required before warmTranfer according to RFC-5359 https://tools.ietf.org/html/rfc5359#section-2.4
Also there is no requirement from HBC or TAS to use hold before blind transfer