### PR TITLE
feat: support to disable autostop for memory leak

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export interface WebPhoneOptions {
     enableDefaultModifiers?: boolean;
     enablePlanB?: boolean;
     stunServers?: any;
+    autoStop?: boolean;
 }
 
 export default class WebPhone {
@@ -195,6 +196,7 @@ export default class WebPhone {
             },
             domain: this.sipInfo.domain,
             autostart: false,
+            autostop: typeof options.autoStop === 'undefined' ? true : options.autoStop, // SIP.js 0.13.x has memory leak with autostop enabled.
             register: true,
             userAgentString,
             sessionDescriptionHandlerFactoryOptions,


### PR DESCRIPTION
SIP.js 0.13.x has memory leak with autostop enabled. 
```js
if (this.configuration.autostop && typeof environment.addEventListener === "function") {
      // Google Chrome Packaged Apps don't allow 'unload' listeners:
      // unload is not available in packaged apps
      if (!((global as any).chrome && (global as any).chrome.app && (global as any).chrome.app.runtime)) {
        this.environListener = this.stop;
        environment.addEventListener("unload", () => this.environListener());
      }
}
```

```js
if (typeof environment.removeEventListener === "function") {
      // Google Chrome Packaged Apps don't allow 'unload' listeners:
      // unload is not available in packaged apps
      if (!((global as any).chrome && (global as any).chrome.app && (global as any).chrome.app.runtime)) {
        environment.removeEventListener("unload", this.environListener);
      }
}
```
Allow developer to disable it and handle by themselves.