### PR TITLE
fix: warm tranfer call get dropped

### DIFF
--- a/src/sip-client.ts
+++ b/src/sip-client.ts
@@ -79,7 +79,8 @@ export class DefaultSipClient extends EventEmitter implements SipClient {
         inboundMessage.subject.startsWith("BYE sip:") ||
         inboundMessage.subject.startsWith("CANCEL sip:") ||
         inboundMessage.subject.startsWith("INFO sip:") ||
-        inboundMessage.subject.startsWith("NOTIFY sip:")
+        inboundMessage.subject.startsWith("NOTIFY sip:") ||
+        inboundMessage.subject.startsWith("UPDATE sip:")
       ) {
         // Auto reply 200 OK to MESSAGE, BYE, CANCEL, INFO, NOTIFY
         await this.reply(


### PR DESCRIPTION
When user receive call from warm transfer, and the warm transfer is completed. Server will send a UPDATE message, if no response for UPDATE, the call will be dropped.