### PR TITLE
feat: add configurable media provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,11 @@ WebPhone uses an in-process browser media provider by default. Supply a
 `mediaProvider` to run call media elsewhere or add provider-specific state.
 SIP dialogs and call lifecycle remain in the SDK.
 
-`callSession.media` contains the provider-defined shape. Legacy browser fields
-retain current behavior with the default provider; custom providers do not
-expose browser-object proxies.
+`mediaProvider.create()` must resolve only after media is ready. Failed creation
+is not cached, so a later initialization attempt retries it. `callSession.media`
+is a read-only view of the provider-defined shape. Legacy browser fields retain
+current behavior with the default provider; custom providers do not expose
+browser-object proxies.
 
 ## Enabling Local Ringtones
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ webPhone.on("inboundCall", (inbundCallSession: InboundCallSession) => {
 });
 ```
 
+## Media providers
+
+WebPhone uses an in-process browser media provider by default. Supply a
+`mediaProvider` to run call media elsewhere or add provider-specific state.
+SIP dialogs and call lifecycle remain in the SDK.
+
+`callSession.media` contains the provider-defined shape. Legacy browser fields
+retain current behavior with the default provider; custom providers do not
+expose browser-object proxies.
+
 ## Enabling Local Ringtones
 
 By default, the SDK does not play a local ringtone. To provide audio feedback,

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -31,6 +31,9 @@ callSession.on("disposed", () => {
 
 ## CallSession events
 
+Media-provider cleanup is best-effort. A call session can emit `disposed`
+before a remote provider completes its own cleanup.
+
 | Event                                   | Description                                                                                                                                                                |
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`answered`](answered.md)               | Triggered when the call is answered.                                                                                                                                       |

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -39,5 +39,6 @@ before a remote provider completes its own cleanup.
 | [`answered`](answered.md)               | Triggered when the call is answered.                                                                                                                                       |
 | [`disposed`](disposed.md)               | For answered calls, this event is triggered when someone hangs up. For inbound calls, it is triggered if the caller hangs up or if the call is answered on another device. |
 | [`inboundMessage`](inboundMessage.md)   | Triggered when you receive a SIP message.                                                                                                                                  |
+| [`mediaError`](mediaError.md)           | Triggered when asynchronously applying remote media state fails after signaling has completed.                                                                              |
 | [`outboundMessage`](outboundMessage.md) | Triggered when a SIP message is sent.                                                                                                                                      |
 | [`ringing`](ringing.md)                 | This event does exist, but it is effectively implied by the existence of other events.                                                                                     |

--- a/docs/events/mediaError.md
+++ b/docs/events/mediaError.md
@@ -1,0 +1,13 @@
+# callSession.on('mediaError', callback)
+
+This event is triggered when the media provider cannot apply an SDP answer after
+the SIP ACK has already been sent. The call remains in its current signaling
+state; handle this event to recover or report the media failure.
+
+## Sample
+
+```ts
+callSession.on("mediaError", (error) => {
+  console.error("Media setup failed", error);
+});
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
           - "answered": events/answered.md
           - "disposed": events/disposed.md
           - "inboundMessage": events/inboundMessage.md
+          - "mediaError": events/mediaError.md
           - "ringing": events/ringing.md
           - "outboundMessage": events/outboundMessage.md
   - "Reference":

--- a/docs/reference/dispose.md
+++ b/docs/reference/dispose.md
@@ -20,3 +20,10 @@ None.
 ## Outputs
 
 None.
+
+## Media provider cleanup
+
+Call-session disposal is owned by the SDK. If a custom media provider performs
+cleanup in another process or tab, the SDK requests that cleanup but does not
+wait for it to finish. A call session transitions to `disposed` independently.
+Remote providers own eventual cleanup, timeouts, and retries.

--- a/docs/reference/reInvite.md
+++ b/docs/reference/reInvite.md
@@ -18,9 +18,12 @@ recovery. For example, if the call was on hold, you want to recover the call but
 keep it on hold.
 
 !!! info "Technical details" `reInvite()` will generate new local SDP and do
-iceRestart. And after server replies with remote SDP, it will be set:
-`rtcPeerConnection.setRemoteDescription(remoteSDP)`. This is required because if
-network information changed, old SDPs won't work any more.
+iceRestart. After the server replies with remote SDP, the media provider applies
+it. This is required because if network information changed, old SDPs won't work
+any more.
+
+The SDK sends the SIP ACK before applying the remote SDP. If media setup then
+fails, `reInvite()` rejects.
 
 See also:
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "check": "biome check . --write",
+    "typecheck": "tsc --project test/tsconfig.json",
     "prepublishOnly": "pnpm build",
     "postpublish": "rm -rf dist",
     "serve": "rm -rf .parcel-cache && parcel serve test/index.html --no-hmr",

--- a/src/call-session/inbound.ts
+++ b/src/call-session/inbound.ts
@@ -1,15 +1,17 @@
 import type WebPhone from "../index.js";
-import type { DefaultMediaObjects } from "../types.js";
 import callControlCommands from "../rc-message/call-control-commands.js";
 import RcMessage from "../rc-message/rc-message.js";
 import type InboundMessage from "../sip-message/inbound.js";
 import type OutboundMessage from "../sip-message/outbound/index.js";
 import RequestMessage from "../sip-message/outbound/request.js";
 import ResponseMessage from "../sip-message/outbound/response.js";
+import type { DefaultMediaObjects } from "../types.js";
 import { branch, fakeDomain, uuid } from "../utils.js";
 import CallSession from "./index.js";
 
-class InboundCallSession<M extends object = DefaultMediaObjects> extends CallSession<M> {
+class InboundCallSession<
+  M extends object = DefaultMediaObjects,
+> extends CallSession<M> {
   public constructor(webPhone: WebPhone<M>, inviteMessage: InboundMessage) {
     super(webPhone);
     this.sipMessage = inviteMessage;
@@ -117,9 +119,7 @@ class InboundCallSession<M extends object = DefaultMediaObjects> extends CallSes
 
     // most INVITE message will have a body with SDP offer.
     if (this.sipMessage.body.length > 0) {
-      const sdp = await this.requireMediaSession().answerOffer(
-        this.sipMessage.body,
-      );
+      const sdp = await this.answerOffer(this.sipMessage.body);
 
       const newMessage = new ResponseMessage(this.sipMessage, {
         responseCode: 200,
@@ -131,7 +131,7 @@ class InboundCallSession<M extends object = DefaultMediaObjects> extends CallSes
       await this.webPhone.sipClient.reply(newMessage);
     } else {
       // some INVITE message has an empty body. For example, when you invoke RESTful API /pickup to answer a call from a call queue
-      const sdp = await this.requireMediaSession().createOffer({
+      const sdp = await this.createOffer({
         iceRestart: true,
       });
 
@@ -146,7 +146,9 @@ class InboundCallSession<M extends object = DefaultMediaObjects> extends CallSes
         newMessage as RequestMessage,
       );
       this.sipMessage = ackMessage;
-      await this.requireMediaSession().applyAnswer(ackMessage.body);
+      void Promise.resolve()
+        .then(() => this.requireMediaSession().applyAnswer(ackMessage.body))
+        .catch(() => {});
     }
 
     this.state = "answered";

--- a/src/call-session/inbound.ts
+++ b/src/call-session/inbound.ts
@@ -146,9 +146,7 @@ class InboundCallSession<
         newMessage as RequestMessage,
       );
       this.sipMessage = ackMessage;
-      void Promise.resolve()
-        .then(() => this.requireMediaSession().applyAnswer(ackMessage.body))
-        .catch(() => {});
+      this.applyAnswerDetached(ackMessage.body);
     }
 
     this.state = "answered";

--- a/src/call-session/inbound.ts
+++ b/src/call-session/inbound.ts
@@ -1,4 +1,5 @@
 import type WebPhone from "../index.js";
+import type { DefaultMediaObjects } from "../types.js";
 import callControlCommands from "../rc-message/call-control-commands.js";
 import RcMessage from "../rc-message/rc-message.js";
 import type InboundMessage from "../sip-message/inbound.js";
@@ -8,8 +9,8 @@ import ResponseMessage from "../sip-message/outbound/response.js";
 import { branch, fakeDomain, uuid } from "../utils.js";
 import CallSession from "./index.js";
 
-class InboundCallSession extends CallSession {
-  public constructor(webPhone: WebPhone, inviteMessage: InboundMessage) {
+class InboundCallSession<M extends object = DefaultMediaObjects> extends CallSession<M> {
+  public constructor(webPhone: WebPhone<M>, inviteMessage: InboundMessage) {
     super(webPhone);
     this.sipMessage = inviteMessage;
     this.localPeer = inviteMessage.headers.To;
@@ -116,45 +117,36 @@ class InboundCallSession extends CallSession {
 
     // most INVITE message will have a body with SDP offer.
     if (this.sipMessage.body.length > 0) {
-      await this.rtcPeerConnection.setRemoteDescription({
-        type: "offer",
-        sdp: this.sipMessage.body,
-      });
-      const answer = await this.rtcPeerConnection.createAnswer();
-      await this.rtcPeerConnection.setLocalDescription(answer);
-      await this.waitForIceGatheringComplete();
+      const sdp = await this.requireMediaSession().answerOffer(
+        this.sipMessage.body,
+      );
 
       const newMessage = new ResponseMessage(this.sipMessage, {
         responseCode: 200,
         headers: {
           "Content-Type": "application/sdp",
         },
-        body: this.rtcPeerConnection.localDescription!.sdp,
+        body: sdp,
       });
       await this.webPhone.sipClient.reply(newMessage);
     } else {
       // some INVITE message has an empty body. For example, when you invoke RESTful API /pickup to answer a call from a call queue
-      const offer = await this.rtcPeerConnection.createOffer({
+      const sdp = await this.requireMediaSession().createOffer({
         iceRestart: true,
       });
-      await this.rtcPeerConnection.setLocalDescription(offer);
-      await this.waitForIceGatheringComplete();
 
       const newMessage = new ResponseMessage(this.sipMessage, {
         responseCode: 200,
         headers: {
           "Content-Type": "application/sdp",
         },
-        body: this.rtcPeerConnection.localDescription!.sdp,
+        body: sdp,
       });
       const ackMessage = await this.webPhone.sipClient.request(
         newMessage as RequestMessage,
       );
       this.sipMessage = ackMessage;
-      this.rtcPeerConnection.setRemoteDescription({
-        type: "answer",
-        sdp: ackMessage.body,
-      });
+      await this.requireMediaSession().applyAnswer(ackMessage.body);
     }
 
     this.state = "answered";

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -45,6 +45,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   public direction!: "inbound" | "outbound";
   private reqid = 1;
   private mediaSession?: MediaSession<M>;
+  private mediaValues: Partial<M> = {};
 
   public constructor(webPhone: WebPhone<M>) {
     super();
@@ -57,17 +58,33 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   public get rtcPeerConnection(): MediaField<M, "rtcPeerConnection"> {
     return this.mediaField("rtcPeerConnection");
   }
+  public set rtcPeerConnection(value: MediaField<M, "rtcPeerConnection">) {
+    this.setMediaField("rtcPeerConnection", value);
+  }
   public get mediaStream(): MediaField<M, "mediaStream"> {
     return this.mediaField("mediaStream");
+  }
+  public set mediaStream(value: MediaField<M, "mediaStream">) {
+    this.setMediaField("mediaStream", value);
+    if (value) this.emit("mediaStreamSet", value);
   }
   public get audioElement(): MediaField<M, "audioElement"> {
     return this.mediaField("audioElement");
   }
+  public set audioElement(value: MediaField<M, "audioElement">) {
+    this.setMediaField("audioElement", value);
+  }
   public get inputDeviceId(): MediaField<M, "inputDeviceId"> {
     return this.mediaField("inputDeviceId");
   }
+  public set inputDeviceId(value: MediaField<M, "inputDeviceId">) {
+    this.setMediaField("inputDeviceId", value);
+  }
   public get outputDeviceId(): MediaField<M, "outputDeviceId"> {
     return this.mediaField("outputDeviceId");
+  }
+  public set outputDeviceId(value: MediaField<M, "outputDeviceId">) {
+    this.setMediaField("outputDeviceId", value);
   }
 
   // for inbound call, this.sipMessage?.headers["Call-Id"] will be the call id
@@ -122,6 +139,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
         deviceManager: this.webPhone.deviceManager,
         onMediaStream: (stream) => this.emit("mediaStreamSet", stream),
       });
+      Object.assign(this.mediaSession.media, this.mediaValues);
     }
     await this.mediaSession.init();
   }
@@ -339,7 +357,15 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   }
 
   private mediaField<K extends PropertyKey>(key: K): MediaField<M, K> {
-    return this.media?.[key as unknown as keyof M] as MediaField<M, K>;
+    return (this.media?.[key as unknown as keyof M] ??
+      this.mediaValues[key as unknown as keyof M]) as MediaField<M, K>;
+  }
+
+  private setMediaField<K extends PropertyKey>(key: K, value: MediaField<M, K>) {
+    this.mediaValues[key as unknown as keyof M] = value as M[keyof M];
+    if (this.media) {
+      this.media[key as unknown as keyof M] = value as M[keyof M];
+    }
   }
 
   protected async sendJsonMessage<T>(

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -52,7 +52,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     this.webPhone = webPhone;
   }
 
-  public get media(): M | undefined {
+  public get media(): Readonly<M> | undefined {
     return this.mediaSession?.media;
   }
   public get rtcPeerConnection(): MediaField<M, "rtcPeerConnection"> {
@@ -140,7 +140,6 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
         onMediaStream: (stream) => this.emit("mediaStreamSet", stream),
       });
     }
-    await this.mediaSession.init();
   }
 
   public async changeInputDevice(deviceId: string) {
@@ -256,7 +255,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     await this.requireMediaSession().sendDtmf(tones, duration, interToneGap);
   }
 
-  public async dispose() {
+  public dispose() {
     void Promise.resolve()
       .then(() => this.mediaSession?.dispose())
       .catch(() => {});
@@ -268,10 +267,10 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   // send re-INVITE.
   // If the call is on hold and you don't want to unhold it, set toReceive to false
   public async reInvite(toReceive: boolean = true) {
-    const sdp = await this.createOffer({
-      iceRestart: true,
-      receive: toReceive,
-    });
+    let sdp = await this.createOffer({ iceRestart: true });
+    if (!toReceive) {
+      sdp = sdp.replace(/a=sendrecv/g, "a=sendonly");
+    }
     const requestMessage = new RequestMessage(
       `INVITE ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -284,9 +283,6 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
       sdp,
     );
     const replyMessage = await this.webPhone.sipClient.request(requestMessage);
-    void Promise.resolve()
-      .then(() => this.requireMediaSession().applyAnswer(replyMessage.body))
-      .catch(() => {});
     const ackMessage = new RequestMessage(
       `ACK ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -298,6 +294,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
       },
     );
     await this.webPhone.sipClient.reply(ackMessage);
+    await this.requireMediaSession().applyAnswer(replyMessage.body);
   }
 
   // handle re-INVITE from SIP server
@@ -373,10 +370,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     return this.mediaSession;
   }
 
-  protected async createOffer(options?: {
-    iceRestart?: boolean;
-    receive?: boolean;
-  }) {
+  protected async createOffer(options?: { iceRestart?: boolean }) {
     const sdp = await this.requireMediaSession().createOffer(options);
     this.localSdp = sdp;
     return sdp;
@@ -386,6 +380,12 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     const answer = await this.requireMediaSession().answerOffer(sdp);
     this.localSdp = answer;
     return answer;
+  }
+
+  protected applyAnswerDetached(sdp: string) {
+    void Promise.resolve()
+      .then(() => this.requireMediaSession().applyAnswer(sdp))
+      .catch((error) => this.emit("mediaError", error));
   }
 
   private mediaField<K extends PropertyKey>(key: K): MediaField<M, K> {

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -1,13 +1,11 @@
+import sdpTransform from "sdp-transform";
+
 import EventEmitter from "../event-emitter.js";
 import type WebPhone from "../index.js";
 import type InboundMessage from "../sip-message/inbound.js";
 import RequestMessage from "../sip-message/outbound/request.js";
 import ResponseMessage from "../sip-message/outbound/response.js";
-import type {
-  DefaultMediaObjects,
-  MediaProvider,
-  MediaSession,
-} from "../types.js";
+import type { DefaultMediaObjects, MediaSession } from "../types.js";
 import {
   branch,
   extractAddress,
@@ -44,6 +42,8 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     "init";
   public direction!: "inbound" | "outbound";
   private reqid = 1;
+  private sdpVersion = 1;
+  private localSdp?: string;
   private mediaSession?: MediaSession<M>;
   private mediaValues: Partial<M> = {};
 
@@ -257,7 +257,9 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   }
 
   public async dispose() {
-    await this.mediaSession?.dispose();
+    void Promise.resolve()
+      .then(() => this.mediaSession?.dispose())
+      .catch(() => {});
     this.state = "disposed";
     this.emit("disposed");
     this.removeAllListeners();
@@ -266,7 +268,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   // send re-INVITE.
   // If the call is on hold and you don't want to unhold it, set toReceive to false
   public async reInvite(toReceive: boolean = true) {
-    const sdp = await this.requireMediaSession().createOffer({
+    const sdp = await this.createOffer({
       iceRestart: true,
       receive: toReceive,
     });
@@ -282,7 +284,9 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
       sdp,
     );
     const replyMessage = await this.webPhone.sipClient.request(requestMessage);
-    await this.requireMediaSession().applyAnswer(replyMessage.body);
+    void Promise.resolve()
+      .then(() => this.requireMediaSession().applyAnswer(replyMessage.body))
+      .catch(() => {});
     const ackMessage = new RequestMessage(
       `ACK ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -299,9 +303,7 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   // handle re-INVITE from SIP server
   public async handleReInvite(reInviteMessage: InboundMessage) {
     this.sipMessage = reInviteMessage;
-    const sdp = await this.requireMediaSession().answerOffer(
-      reInviteMessage.body,
-    );
+    const sdp = await this.answerOffer(reInviteMessage.body);
 
     const newMessage = new ResponseMessage(this.sipMessage, {
       responseCode: 200,
@@ -322,7 +324,23 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     if (!this.mediaSession) {
       return;
     }
-    const sdp = await this.mediaSession.createOffer({ receive: toReceive });
+    let sdp = this.localSdp;
+    if (!sdp) {
+      return;
+    }
+    if (!toReceive) {
+      sdp = sdp.replace(/a=sendrecv/g, "a=sendonly");
+    }
+    const parsed = sdpTransform.parse(sdp);
+    if (!parsed.origin) {
+      throw new Error("Local SDP is missing an origin");
+    }
+    this.sdpVersion = Math.max(
+      this.sdpVersion,
+      parsed.origin.sessionVersion + 1,
+    );
+    parsed.origin.sessionVersion = this.sdpVersion++;
+    sdp = sdpTransform.write(parsed);
     const requestMessage = new RequestMessage(
       `INVITE ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -355,16 +373,35 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
     return this.mediaSession;
   }
 
+  protected async createOffer(options?: {
+    iceRestart?: boolean;
+    receive?: boolean;
+  }) {
+    const sdp = await this.requireMediaSession().createOffer(options);
+    this.localSdp = sdp;
+    return sdp;
+  }
+
+  protected async answerOffer(sdp: string) {
+    const answer = await this.requireMediaSession().answerOffer(sdp);
+    this.localSdp = answer;
+    return answer;
+  }
+
   private mediaField<K extends PropertyKey>(key: K): MediaField<M, K> {
     if (this.mediaSession) {
-      return this.mediaSession.media[
-        key as unknown as keyof M
-      ] as MediaField<M, K>;
+      return this.mediaSession.media[key as unknown as keyof M] as MediaField<
+        M,
+        K
+      >;
     }
     return this.mediaValues[key as unknown as keyof M] as MediaField<M, K>;
   }
 
-  private setMediaField<K extends PropertyKey>(key: K, value: MediaField<M, K>) {
+  private setMediaField<K extends PropertyKey>(
+    key: K,
+    value: MediaField<M, K>,
+  ) {
     if (this.mediaSession) {
       this.mediaSession.media[key as unknown as keyof M] = value as M[keyof M];
     } else {

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -139,7 +139,6 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
         deviceManager: this.webPhone.deviceManager,
         onMediaStream: (stream) => this.emit("mediaStreamSet", stream),
       });
-      Object.assign(this.mediaSession.media, this.mediaValues);
     }
     await this.mediaSession.init();
   }
@@ -357,14 +356,19 @@ class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
   }
 
   private mediaField<K extends PropertyKey>(key: K): MediaField<M, K> {
-    return (this.media?.[key as unknown as keyof M] ??
-      this.mediaValues[key as unknown as keyof M]) as MediaField<M, K>;
+    if (this.mediaSession) {
+      return this.mediaSession.media[
+        key as unknown as keyof M
+      ] as MediaField<M, K>;
+    }
+    return this.mediaValues[key as unknown as keyof M] as MediaField<M, K>;
   }
 
   private setMediaField<K extends PropertyKey>(key: K, value: MediaField<M, K>) {
-    this.mediaValues[key as unknown as keyof M] = value as M[keyof M];
-    if (this.media) {
-      this.media[key as unknown as keyof M] = value as M[keyof M];
+    if (this.mediaSession) {
+      this.mediaSession.media[key as unknown as keyof M] = value as M[keyof M];
+    } else {
+      this.mediaValues[key as unknown as keyof M] = value as M[keyof M];
     }
   }
 

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -1,10 +1,13 @@
-import sdpTransform from "sdp-transform";
-
 import EventEmitter from "../event-emitter.js";
 import type WebPhone from "../index.js";
 import type InboundMessage from "../sip-message/inbound.js";
 import RequestMessage from "../sip-message/outbound/request.js";
 import ResponseMessage from "../sip-message/outbound/response.js";
+import type {
+  DefaultMediaObjects,
+  MediaProvider,
+  MediaSession,
+} from "../types.js";
 import {
   branch,
   extractAddress,
@@ -28,34 +31,43 @@ type FlipResult = CommandResult & {
 };
 const DEFAULT_TRANSFER_TIMEOUT_MS = 10000;
 
-class CallSession extends EventEmitter {
-  public webPhone: WebPhone;
+type MediaField<M, K extends PropertyKey> = K extends keyof M
+  ? M[K]
+  : undefined;
+
+class CallSession<M extends object = DefaultMediaObjects> extends EventEmitter {
+  public webPhone: WebPhone<M>;
   public sipMessage!: InboundMessage;
   public localPeer!: string;
   public remotePeer!: string;
-  public rtcPeerConnection!: RTCPeerConnection;
-  public _mediaStream?: MediaStream;
-  public audioElement!: HTMLAudioElement;
   public state: "init" | "ringing" | "answered" | "disposed" | "failed" =
     "init";
   public direction!: "inbound" | "outbound";
-  public inputDeviceId!: string;
-  public outputDeviceId: string | undefined;
-
   private reqid = 1;
-  private sdpVersion = 1;
+  private mediaSession?: MediaSession<M>;
 
-  public constructor(webPhone: WebPhone) {
+  public constructor(webPhone: WebPhone<M>) {
     super();
     this.webPhone = webPhone;
   }
 
-  public get mediaStream(): MediaStream | undefined {
-    return this._mediaStream;
+  public get media(): M | undefined {
+    return this.mediaSession?.media;
   }
-  public set mediaStream(stream: MediaStream) {
-    this._mediaStream = stream;
-    this.emit("mediaStreamSet", stream);
+  public get rtcPeerConnection(): MediaField<M, "rtcPeerConnection"> {
+    return this.mediaField("rtcPeerConnection");
+  }
+  public get mediaStream(): MediaField<M, "mediaStream"> {
+    return this.mediaField("mediaStream");
+  }
+  public get audioElement(): MediaField<M, "audioElement"> {
+    return this.mediaField("audioElement");
+  }
+  public get inputDeviceId(): MediaField<M, "inputDeviceId"> {
+    return this.mediaField("inputDeviceId");
+  }
+  public get outputDeviceId(): MediaField<M, "outputDeviceId"> {
+    return this.mediaField("outputDeviceId");
   }
 
   // for inbound call, this.sipMessage?.headers["Call-Id"] will be the call id
@@ -102,75 +114,24 @@ class CallSession extends EventEmitter {
   }
 
   public async init() {
-    this.rtcPeerConnection = new RTCPeerConnection({
-      iceServers:
-        this.webPhone.sipInfo.stunServers?.map((url) => ({
-          urls: `stun:${url}`,
-        })) ?? [],
-    });
-
-    // line below is to make sure that you have the permission to access the microphone
-    const tempStream = await navigator.mediaDevices.getUserMedia({
-      audio: true,
-      video: false,
-    });
-    for (const track of tempStream.getTracks()) track.stop(); // 🔥 Stop immediately!
-
-    this.inputDeviceId = await this.webPhone.deviceManager.getInputDeviceId();
-    this.mediaStream = await navigator.mediaDevices.getUserMedia({
-      video: false,
-      audio: { deviceId: { exact: this.inputDeviceId } },
-    });
-    this.mediaStream.getAudioTracks().forEach((track) => {
-      const rtcRtpSender = this.rtcPeerConnection.addTrack(track);
-
-      // ref: https://github.com/ringcentral/ringcentral-web-phone/issues/257
-      const params = rtcRtpSender.getParameters();
-      if (!params.encodings || params.encodings.length === 0) {
-        params.encodings = [{}];
-      }
-      params.encodings.forEach((encoding) => {
-        encoding.priority = "high";
+    if (!this.mediaSession) {
+      this.mediaSession = await this.webPhone.mediaProvider.create({
+        callId: this.callId,
+        direction: this.direction,
+        iceServers: this.webPhone.sipInfo.stunServers ?? [],
+        deviceManager: this.webPhone.deviceManager,
+        onMediaStream: (stream) => this.emit("mediaStreamSet", stream),
       });
-      rtcRtpSender.setParameters(params);
-    });
-    this.rtcPeerConnection.ontrack = async (event) => {
-      const remoteStream = event.streams[0];
-      this.audioElement = document.createElement("audio") as HTMLAudioElement;
-      this.audioElement.hidden = true;
-      this.audioElement.autoplay = true;
-      this.audioElement.srcObject = remoteStream;
-
-      // this code should be run last
-      this.outputDeviceId =
-        await this.webPhone.deviceManager.getOutputDeviceId();
-      if (this.outputDeviceId) {
-        this.audioElement.setSinkId(this.outputDeviceId);
-      }
-    };
+    }
+    await this.mediaSession.init();
   }
 
   public async changeInputDevice(deviceId: string) {
-    this.inputDeviceId = deviceId;
-    for (const track of this.mediaStream?.getAudioTracks() ?? []) track.stop();
-    this.mediaStream = await navigator.mediaDevices.getUserMedia({
-      video: false,
-      audio: { deviceId: { exact: deviceId } },
-    });
-    const newAudioTrack = this.mediaStream.getAudioTracks()[0];
-    const sender = this.rtcPeerConnection
-      .getSenders()
-      .find((sender) => sender.track?.kind === "audio");
-    if (sender) {
-      sender.replaceTrack(newAudioTrack);
-    }
+    await this.requireMediaSession().changeInputDevice(deviceId);
   }
 
   public async changeOutputDevice(deviceId: string) {
-    this.outputDeviceId = deviceId;
-    if (deviceId) {
-      await this.audioElement.setSinkId(deviceId);
-    }
+    await this.requireMediaSession().changeOutputDevice(deviceId);
   }
 
   public async transfer(target: string, timeout = DEFAULT_TRANSFER_TIMEOUT_MS) {
@@ -183,7 +144,7 @@ class CallSession extends EventEmitter {
   ): Promise<{
     complete: () => Promise<void>;
     cancel: () => Promise<void>;
-    newSession: OutboundCallSession;
+    newSession: OutboundCallSession<M>;
   }> {
     await this.hold();
     // create a new session and user needs to talk to the target before transfer
@@ -206,7 +167,7 @@ class CallSession extends EventEmitter {
   }
 
   public async completeWarmTransfer(
-    existingSession: CallSession,
+    existingSession: CallSession<M>,
     timeout = DEFAULT_TRANSFER_TIMEOUT_MS,
   ) {
     const target = existingSession.remoteNumber;
@@ -263,80 +224,35 @@ class CallSession extends EventEmitter {
     await this.toggleReceive(true);
   }
 
-  public mute() {
-    this.toggleTrack(false);
+  public async mute() {
+    await this.requireMediaSession().setMuted(true);
   }
-  public unmute() {
-    this.toggleTrack(true);
-  }
-
-  public sendDtmf(tones: string, duration?: number, interToneGap?: number) {
-    for (const sender of this.rtcPeerConnection.getSenders()) {
-      if (sender.dtmf?.canInsertDTMF) {
-        sender.dtmf?.insertDTMF(tones, duration, interToneGap);
-      }
-    }
+  public async unmute() {
+    await this.requireMediaSession().setMuted(false);
   }
 
-  public dispose() {
-    this.rtcPeerConnection?.close();
-    for (const track of this.mediaStream?.getTracks() ?? []) track.stop();
-    if (this.audioElement) {
-      this.audioElement.srcObject = null;
-    }
+  public async sendDtmf(
+    tones: string,
+    duration?: number,
+    interToneGap?: number,
+  ) {
+    await this.requireMediaSession().sendDtmf(tones, duration, interToneGap);
+  }
+
+  public async dispose() {
+    await this.mediaSession?.dispose();
     this.state = "disposed";
     this.emit("disposed");
     this.removeAllListeners();
   }
 
-  // for mute/unmute
-  protected toggleTrack(enabled: boolean) {
-    this.rtcPeerConnection.getSenders().forEach((sender) => {
-      if (sender.track) {
-        sender.track.enabled = enabled;
-      }
-    });
-  }
-
-  protected async waitForIceGatheringComplete(timeoutMs = 2000) {
-    if (this.rtcPeerConnection.iceGatheringState === "complete") {
-      return;
-    }
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => {
-        cleanup();
-        resolve();
-      }, timeoutMs);
-      const onIceCandidate = (event: RTCPeerConnectionIceEvent) => {
-        if (event.candidate === null) {
-          cleanup();
-          resolve();
-        }
-      };
-      const cleanup = () => {
-        clearTimeout(timeout);
-        this.rtcPeerConnection.removeEventListener(
-          "icecandidate",
-          onIceCandidate,
-        );
-      };
-      this.rtcPeerConnection.addEventListener("icecandidate", onIceCandidate);
-    });
-  }
-
   // send re-INVITE.
   // If the call is on hold and you don't want to unhold it, set toReceive to false
   public async reInvite(toReceive: boolean = true) {
-    const offer = await this.rtcPeerConnection.createOffer({
+    const sdp = await this.requireMediaSession().createOffer({
       iceRestart: true,
+      receive: toReceive,
     });
-    await this.rtcPeerConnection.setLocalDescription(offer);
-    await this.waitForIceGatheringComplete();
-    let sdp = this.rtcPeerConnection.localDescription!.sdp;
-    // default value is `a=sendrecv`
-    if (!toReceive) {
-      sdp = sdp.replace(/a=sendrecv/g, "a=sendonly");
-    }
     const requestMessage = new RequestMessage(
       `INVITE ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -349,10 +265,7 @@ class CallSession extends EventEmitter {
       sdp,
     );
     const replyMessage = await this.webPhone.sipClient.request(requestMessage);
-    await this.rtcPeerConnection.setRemoteDescription({
-      type: "answer",
-      sdp: replyMessage.body,
-    });
+    await this.requireMediaSession().applyAnswer(replyMessage.body);
     const ackMessage = new RequestMessage(
       `ACK ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -369,20 +282,16 @@ class CallSession extends EventEmitter {
   // handle re-INVITE from SIP server
   public async handleReInvite(reInviteMessage: InboundMessage) {
     this.sipMessage = reInviteMessage;
-    await this.rtcPeerConnection.setRemoteDescription({
-      type: "offer",
-      sdp: reInviteMessage.body,
-    });
-    const answer = await this.rtcPeerConnection.createAnswer();
-    await this.rtcPeerConnection.setLocalDescription(answer);
-    await this.waitForIceGatheringComplete();
+    const sdp = await this.requireMediaSession().answerOffer(
+      reInviteMessage.body,
+    );
 
     const newMessage = new ResponseMessage(this.sipMessage, {
       responseCode: 200,
       headers: {
         "Content-Type": "application/sdp",
       },
-      body: this.rtcPeerConnection.localDescription!.sdp,
+      body: sdp,
     });
     await this.webPhone.sipClient.reply(newMessage);
 
@@ -393,19 +302,10 @@ class CallSession extends EventEmitter {
   // for hold/unhold
   // toggle between a=sendrecv and a=sendonly
   protected async toggleReceive(toReceive: boolean) {
-    if (!this.rtcPeerConnection?.localDescription) {
+    if (!this.mediaSession) {
       return;
     }
-    let sdp = this.rtcPeerConnection.localDescription!.sdp;
-    // default value is `a=sendrecv`
-    if (!toReceive) {
-      sdp = sdp.replace(/a=sendrecv/g, "a=sendonly");
-    }
-    // increase the sdp version
-    const res = sdpTransform.parse(sdp);
-    this.sdpVersion = Math.max(this.sdpVersion, res.origin!.sessionVersion + 1);
-    res.origin!.sessionVersion = this.sdpVersion++;
-    sdp = sdpTransform.write(res);
+    const sdp = await this.mediaSession.createOffer({ receive: toReceive });
     const requestMessage = new RequestMessage(
       `INVITE ${extractAddress(this.remotePeer)} SIP/2.0`,
       {
@@ -429,6 +329,17 @@ class CallSession extends EventEmitter {
       },
     );
     await this.webPhone.sipClient.reply(ackMessage);
+  }
+
+  protected requireMediaSession() {
+    if (!this.mediaSession) {
+      throw new Error("Media session has not been initialized");
+    }
+    return this.mediaSession;
+  }
+
+  private mediaField<K extends PropertyKey>(key: K): MediaField<M, K> {
+    return this.media?.[key as unknown as keyof M] as MediaField<M, K>;
   }
 
   protected async sendJsonMessage<T>(

--- a/src/call-session/outbound.ts
+++ b/src/call-session/outbound.ts
@@ -104,9 +104,6 @@ class OutboundCallSession<
 
           this.state = "answered";
           this.emit("answered");
-          void Promise.resolve()
-            .then(() => this.requireMediaSession().applyAnswer(message.body))
-            .catch(() => {});
           const ackMessage = new RequestMessage(
             `ACK ${extractAddress(this.remotePeer)} SIP/2.0`,
             {
@@ -118,6 +115,7 @@ class OutboundCallSession<
             },
           );
           await this.webPhone.sipClient.reply(ackMessage);
+          this.applyAnswerDetached(message.body);
           resolve(true);
         }
       };

--- a/src/call-session/outbound.ts
+++ b/src/call-session/outbound.ts
@@ -1,4 +1,5 @@
 import type WebPhone from "../index.js";
+import type { DefaultMediaObjects } from "../types.js";
 import type InboundMessage from "../sip-message/inbound.js";
 import RequestMessage from "../sip-message/outbound/request.js";
 import {
@@ -12,8 +13,8 @@ import {
 } from "../utils.js";
 import CallSession from "./index.js";
 
-class OutboundCallSession extends CallSession {
-  public constructor(webPhone: WebPhone, callee: string) {
+class OutboundCallSession<M extends object = DefaultMediaObjects> extends CallSession<M> {
+  public constructor(webPhone: WebPhone<M>, callee: string) {
     super(webPhone);
     this.callee = callee;
     this.direction = "outbound";
@@ -28,11 +29,9 @@ class OutboundCallSession extends CallSession {
     callerId?: string,
     options?: { headers?: Record<string, string> },
   ) {
-    const offer = await this.rtcPeerConnection.createOffer({
+    const sdp = await this.requireMediaSession().createOffer({
       iceRestart: true,
     });
-    await this.rtcPeerConnection.setLocalDescription(offer);
-    await this.waitForIceGatheringComplete();
 
     const inviteMessage = new RequestMessage(
       `INVITE sip:${this.callee}@${this.webPhone.sipInfo.domain} SIP/2.0`,
@@ -44,7 +43,7 @@ class OutboundCallSession extends CallSession {
         Via: `SIP/2.0/WSS ${fakeDomain};branch=${branch()}`,
         "Content-Type": "application/sdp",
       },
-      this.rtcPeerConnection.localDescription!.sdp,
+      sdp,
     );
     if (callerId) {
       inviteMessage.headers["P-Asserted-Identity"] =
@@ -96,17 +95,14 @@ class OutboundCallSession extends CallSession {
             if (index !== -1) {
               this.webPhone.callSessions.splice(index, 1);
             }
-            this.dispose();
+            await this.dispose();
             resolve(false);
             return;
           }
 
           this.state = "answered";
           this.emit("answered");
-          this.rtcPeerConnection.setRemoteDescription({
-            type: "answer",
-            sdp: message.body,
-          });
+          await this.requireMediaSession().applyAnswer(message.body);
           const ackMessage = new RequestMessage(
             `ACK ${extractAddress(this.remotePeer)} SIP/2.0`,
             {

--- a/src/call-session/outbound.ts
+++ b/src/call-session/outbound.ts
@@ -1,7 +1,7 @@
 import type WebPhone from "../index.js";
-import type { DefaultMediaObjects } from "../types.js";
 import type InboundMessage from "../sip-message/inbound.js";
 import RequestMessage from "../sip-message/outbound/request.js";
+import type { DefaultMediaObjects } from "../types.js";
 import {
   branch,
   extractAddress,
@@ -13,7 +13,9 @@ import {
 } from "../utils.js";
 import CallSession from "./index.js";
 
-class OutboundCallSession<M extends object = DefaultMediaObjects> extends CallSession<M> {
+class OutboundCallSession<
+  M extends object = DefaultMediaObjects,
+> extends CallSession<M> {
   public constructor(webPhone: WebPhone<M>, callee: string) {
     super(webPhone);
     this.callee = callee;
@@ -29,7 +31,7 @@ class OutboundCallSession<M extends object = DefaultMediaObjects> extends CallSe
     callerId?: string,
     options?: { headers?: Record<string, string> },
   ) {
-    const sdp = await this.requireMediaSession().createOffer({
+    const sdp = await this.createOffer({
       iceRestart: true,
     });
 
@@ -102,7 +104,9 @@ class OutboundCallSession<M extends object = DefaultMediaObjects> extends CallSe
 
           this.state = "answered";
           this.emit("answered");
-          await this.requireMediaSession().applyAnswer(message.body);
+          void Promise.resolve()
+            .then(() => this.requireMediaSession().applyAnswer(message.body))
+            .catch(() => {});
           const ackMessage = new RequestMessage(
             `ACK ${extractAddress(this.remotePeer)} SIP/2.0`,
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,32 +3,46 @@ import type CallSession from "./call-session/index.js";
 import OutboundCallSession from "./call-session/outbound.js";
 import { DefaultDeviceManager } from "./device-manager.js";
 import EventEmitter from "./event-emitter.js";
+import { DefaultMediaProvider } from "./media-provider.js";
 import { DefaultSipClient } from "./sip-client.js";
 import type InboundMessage from "./sip-message/inbound.js";
 import ResponseMessage from "./sip-message/outbound/response.js";
 import type {
   DeviceManager,
+  DefaultMediaObjects,
+  MediaProvider,
   SipClient,
   SipInfo,
   WebPhoneOptions,
 } from "./types.js";
 
-class WebPhone extends EventEmitter {
+export { DefaultMediaProvider } from "./media-provider.js";
+export type {
+  DefaultMediaObjects,
+  MediaProvider,
+  MediaProviderContext,
+  MediaSession,
+} from "./types.js";
+
+class WebPhone<M extends object = DefaultMediaObjects> extends EventEmitter {
   public sipInfo: SipInfo;
   public sipClient: SipClient;
   public deviceManager: DeviceManager;
-  public callSessions: CallSession[] = [];
+  public callSessions: CallSession<M>[] = [];
+  public mediaProvider: MediaProvider<M>;
   public autoAnswer = true;
-  public options: WebPhoneOptions;
+  public options: WebPhoneOptions<M>;
 
   public disposed = false;
 
-  public constructor(options: WebPhoneOptions) {
+  public constructor(options: WebPhoneOptions<M>) {
     super();
     this.options = options;
     this.sipInfo = options.sipInfo;
     this.sipClient = options.sipClient ?? new DefaultSipClient(options);
     this.deviceManager = options.deviceManager ?? new DefaultDeviceManager();
+    this.mediaProvider =
+      options.mediaProvider ?? (new DefaultMediaProvider() as MediaProvider<M>);
     this.autoAnswer = options.autoAnswer ?? true;
 
     this.sipClient.on(
@@ -46,7 +60,7 @@ class WebPhone extends EventEmitter {
           if (index !== -1) {
             const callSession = this.callSessions[index];
             this.callSessions.splice(index, 1);
-            callSession.dispose();
+            await callSession.dispose();
           }
         }
 
@@ -68,11 +82,11 @@ class WebPhone extends EventEmitter {
           return;
         }
 
-        this.callSessions.push(new InboundCallSession(this, inboundMessage));
+        this.callSessions.push(new InboundCallSession<M>(this, inboundMessage));
         // write it this way so that it will be compatible with manate, inboundCallSession will be managed
         const inboundCallSession = this.callSessions[
           this.callSessions.length - 1
-        ] as InboundCallSession;
+        ] as InboundCallSession<M>;
         this.emit("inboundCall", inboundCallSession);
 
         // tell SIP server that we are ringing
@@ -122,9 +136,9 @@ class WebPhone extends EventEmitter {
       if (callSession.state === "answered") {
         await callSession.hangup();
       } else if (callSession.direction === "inbound") {
-        await (callSession as InboundCallSession).decline();
+        await (callSession as InboundCallSession<M>).decline();
       } else {
-        await (callSession as OutboundCallSession).cancel();
+        await (callSession as OutboundCallSession<M>).cancel();
       }
       // callSession.dispose() will be auto triggered by the above methods
     }
@@ -138,11 +152,11 @@ class WebPhone extends EventEmitter {
     callerId?: string,
     options?: { headers?: Record<string, string> },
   ) {
-    this.callSessions.push(new OutboundCallSession(this, callee));
+    this.callSessions.push(new OutboundCallSession<M>(this, callee));
     // write it this way so that it will be compatible with manate, outboundCallSession will be managed
     const outboundCallSession = this.callSessions[
       this.callSessions.length - 1
-    ] as OutboundCallSession;
+    ] as OutboundCallSession<M>;
     this.emit("outboundCall", outboundCallSession);
     await outboundCallSession.init();
     await outboundCallSession.call(callerId, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { DefaultSipClient } from "./sip-client.js";
 import type InboundMessage from "./sip-message/inbound.js";
 import ResponseMessage from "./sip-message/outbound/response.js";
 import type {
-  DeviceManager,
   DefaultMediaObjects,
+  DeviceManager,
   MediaProvider,
   SipClient,
   SipInfo,
@@ -40,8 +40,8 @@ class WebPhone<M extends object = DefaultMediaObjects> extends EventEmitter {
     this.sipInfo = options.sipInfo;
     this.sipClient = options.sipClient ?? new DefaultSipClient(options);
     this.deviceManager = options.deviceManager ?? new DefaultDeviceManager();
-    this.mediaProvider =
-      options.mediaProvider ?? (new DefaultMediaProvider() as MediaProvider<M>);
+    this.mediaProvider = (options.mediaProvider ??
+      new DefaultMediaProvider()) as MediaProvider<M>;
     this.autoAnswer = options.autoAnswer ?? true;
 
     this.sipClient.on(

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import type {
   WebPhoneOptions,
 } from "./types.js";
 
-export { DefaultMediaProvider } from "./media-provider.js";
 export type {
   DefaultMediaObjects,
   MediaProvider,

--- a/src/media-provider.ts
+++ b/src/media-provider.ts
@@ -1,5 +1,3 @@
-import sdpTransform from "sdp-transform";
-
 import type {
   DefaultMediaObjects,
   MediaProvider,
@@ -13,13 +11,21 @@ export class DefaultMediaProvider
   public async create(
     context: MediaProviderContext,
   ): Promise<MediaSession<DefaultMediaObjects>> {
-    return new DefaultMediaSession(context);
+    const session = new DefaultMediaSession(context);
+    try {
+      await session.init();
+      return session;
+    } catch (error) {
+      try {
+        await session.dispose();
+      } catch {}
+      throw error;
+    }
   }
 }
 
 class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
   public media = {} as DefaultMediaObjects;
-  private sdpVersion = 1;
 
   public constructor(private context: MediaProviderContext) {}
 
@@ -59,10 +65,8 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
 
   public async createOffer({
     iceRestart = false,
-    receive = true,
   }: {
     iceRestart?: boolean;
-    receive?: boolean;
   } = {}) {
     const rtcPeerConnection = this.media.rtcPeerConnection;
     if (iceRestart || !rtcPeerConnection.localDescription) {
@@ -70,20 +74,7 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
       await rtcPeerConnection.setLocalDescription(offer);
       await this.waitForIceGatheringComplete();
     }
-    let sdp = rtcPeerConnection.localDescription!.sdp!;
-    if (!receive) {
-      sdp = sdp.replace(/a=sendrecv/g, "a=sendonly");
-    }
-    if (!iceRestart) {
-      const parsed = sdpTransform.parse(sdp);
-      this.sdpVersion = Math.max(
-        this.sdpVersion,
-        parsed.origin!.sessionVersion + 1,
-      );
-      parsed.origin!.sessionVersion = this.sdpVersion++;
-      sdp = sdpTransform.write(parsed);
-    }
-    return sdp;
+    return rtcPeerConnection.localDescription!.sdp!;
   }
 
   public async answerOffer(sdp: string) {

--- a/src/media-provider.ts
+++ b/src/media-provider.ts
@@ -28,7 +28,9 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
       return;
     }
     this.media.rtcPeerConnection = new RTCPeerConnection({
-      iceServers: this.context.iceServers.map((urls) => ({ urls: `stun:${urls}` })),
+      iceServers: this.context.iceServers.map((urls) => ({
+        urls: `stun:${urls}`,
+      })),
     });
 
     const tempStream = await navigator.mediaDevices.getUserMedia({
@@ -58,7 +60,10 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
   public async createOffer({
     iceRestart = false,
     receive = true,
-  }: { iceRestart?: boolean; receive?: boolean } = {}) {
+  }: {
+    iceRestart?: boolean;
+    receive?: boolean;
+  } = {}) {
     const rtcPeerConnection = this.media.rtcPeerConnection;
     if (iceRestart || !rtcPeerConnection.localDescription) {
       const offer = await rtcPeerConnection.createOffer({ iceRestart });

--- a/src/media-provider.ts
+++ b/src/media-provider.ts
@@ -1,0 +1,191 @@
+import sdpTransform from "sdp-transform";
+
+import type {
+  DefaultMediaObjects,
+  MediaProvider,
+  MediaProviderContext,
+  MediaSession,
+} from "./types.js";
+
+export class DefaultMediaProvider
+  implements MediaProvider<DefaultMediaObjects>
+{
+  public async create(
+    context: MediaProviderContext,
+  ): Promise<MediaSession<DefaultMediaObjects>> {
+    return new DefaultMediaSession(context);
+  }
+}
+
+class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
+  public media = {} as DefaultMediaObjects;
+  private sdpVersion = 1;
+
+  public constructor(private context: MediaProviderContext) {}
+
+  public async init() {
+    if (this.media.rtcPeerConnection) {
+      return;
+    }
+    this.media.rtcPeerConnection = new RTCPeerConnection({
+      iceServers: this.context.iceServers.map((urls) => ({ urls: `stun:${urls}` })),
+    });
+
+    const tempStream = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+      video: false,
+    });
+    for (const track of tempStream.getTracks()) track.stop();
+
+    this.media.inputDeviceId =
+      await this.context.deviceManager.getInputDeviceId();
+    await this.setInputStream(this.media.inputDeviceId);
+    this.media.rtcPeerConnection.ontrack = async (event) => {
+      const audioElement = document.createElement("audio");
+      audioElement.hidden = true;
+      audioElement.autoplay = true;
+      audioElement.srcObject = event.streams[0];
+      this.media.audioElement = audioElement;
+      this.media.outputDeviceId =
+        await this.context.deviceManager.getOutputDeviceId();
+      if (this.media.outputDeviceId) {
+        await audioElement.setSinkId(this.media.outputDeviceId);
+      }
+    };
+  }
+
+  public async createOffer({
+    iceRestart = false,
+    receive = true,
+  }: { iceRestart?: boolean; receive?: boolean } = {}) {
+    const rtcPeerConnection = this.media.rtcPeerConnection;
+    if (iceRestart || !rtcPeerConnection.localDescription) {
+      const offer = await rtcPeerConnection.createOffer({ iceRestart });
+      await rtcPeerConnection.setLocalDescription(offer);
+      await this.waitForIceGatheringComplete();
+    }
+    let sdp = rtcPeerConnection.localDescription!.sdp!;
+    if (!receive) {
+      sdp = sdp.replace(/a=sendrecv/g, "a=sendonly");
+    }
+    if (!iceRestart) {
+      const parsed = sdpTransform.parse(sdp);
+      this.sdpVersion = Math.max(
+        this.sdpVersion,
+        parsed.origin!.sessionVersion + 1,
+      );
+      parsed.origin!.sessionVersion = this.sdpVersion++;
+      sdp = sdpTransform.write(parsed);
+    }
+    return sdp;
+  }
+
+  public async answerOffer(sdp: string) {
+    const rtcPeerConnection = this.media.rtcPeerConnection;
+    await rtcPeerConnection.setRemoteDescription({ type: "offer", sdp });
+    const answer = await rtcPeerConnection.createAnswer();
+    await rtcPeerConnection.setLocalDescription(answer);
+    await this.waitForIceGatheringComplete();
+    return rtcPeerConnection.localDescription!.sdp!;
+  }
+
+  public async applyAnswer(sdp: string) {
+    await this.media.rtcPeerConnection.setRemoteDescription({
+      type: "answer",
+      sdp,
+    });
+  }
+
+  public async changeInputDevice(deviceId: string) {
+    for (const track of this.media.mediaStream?.getAudioTracks() ?? []) {
+      track.stop();
+    }
+    await this.setInputStream(deviceId);
+    const newAudioTrack = this.media.mediaStream!.getAudioTracks()[0];
+    const sender = this.media.rtcPeerConnection
+      .getSenders()
+      .find((candidate) => candidate.track?.kind === "audio");
+    if (sender) {
+      await sender.replaceTrack(newAudioTrack);
+    }
+  }
+
+  public async changeOutputDevice(deviceId: string) {
+    this.media.outputDeviceId = deviceId;
+    if (deviceId) {
+      await this.media.audioElement.setSinkId(deviceId);
+    }
+  }
+
+  public async setMuted(muted: boolean) {
+    this.media.rtcPeerConnection.getSenders().forEach((sender) => {
+      if (sender.track) {
+        sender.track.enabled = !muted;
+      }
+    });
+  }
+
+  public async sendDtmf(
+    tones: string,
+    duration?: number,
+    interToneGap?: number,
+  ) {
+    for (const sender of this.media.rtcPeerConnection.getSenders()) {
+      if (sender.dtmf?.canInsertDTMF) {
+        sender.dtmf.insertDTMF(tones, duration, interToneGap);
+      }
+    }
+  }
+
+  public async dispose() {
+    this.media.rtcPeerConnection?.close();
+    for (const track of this.media.mediaStream?.getTracks() ?? []) track.stop();
+    if (this.media.audioElement) {
+      this.media.audioElement.srcObject = null;
+    }
+  }
+
+  private async setInputStream(deviceId: string) {
+    this.media.inputDeviceId = deviceId;
+    this.media.mediaStream = await navigator.mediaDevices.getUserMedia({
+      video: false,
+      audio: { deviceId: { exact: deviceId } },
+    });
+    this.context.onMediaStream?.(this.media.mediaStream);
+    this.media.mediaStream.getAudioTracks().forEach((track) => {
+      const sender = this.media.rtcPeerConnection.addTrack(track);
+      const params = sender.getParameters();
+      if (!params.encodings || params.encodings.length === 0) {
+        params.encodings = [{}];
+      }
+      params.encodings.forEach((encoding) => {
+        encoding.priority = "high";
+      });
+      sender.setParameters(params);
+    });
+  }
+
+  private async waitForIceGatheringComplete(timeoutMs = 2000) {
+    const rtcPeerConnection = this.media.rtcPeerConnection;
+    if (rtcPeerConnection.iceGatheringState === "complete") {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, timeoutMs);
+      const onIceCandidate = (event: RTCPeerConnectionIceEvent) => {
+        if (event.candidate === null) {
+          cleanup();
+          resolve();
+        }
+      };
+      const cleanup = () => {
+        clearTimeout(timeout);
+        rtcPeerConnection.removeEventListener("icecandidate", onIceCandidate);
+      };
+      rtcPeerConnection.addEventListener("icecandidate", onIceCandidate);
+    });
+  }
+}

--- a/src/media-provider.ts
+++ b/src/media-provider.ts
@@ -37,9 +37,10 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
     });
     for (const track of tempStream.getTracks()) track.stop();
 
-    this.media.inputDeviceId =
-      await this.context.deviceManager.getInputDeviceId();
-    await this.setInputStream(this.media.inputDeviceId);
+    const inputDeviceId = await this.context.deviceManager.getInputDeviceId();
+    const stream = await this.getInputStream(inputDeviceId);
+    this.commitInputStream(inputDeviceId, stream);
+    this.addInputTracks(stream);
     this.media.rtcPeerConnection.ontrack = async (event) => {
       const audioElement = document.createElement("audio");
       audioElement.hidden = true;
@@ -97,16 +98,25 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
   }
 
   public async changeInputDevice(deviceId: string) {
-    for (const track of this.media.mediaStream?.getAudioTracks() ?? []) {
-      track.stop();
-    }
-    await this.setInputStream(deviceId);
-    const newAudioTrack = this.media.mediaStream!.getAudioTracks()[0];
+    const previousStream = this.media.mediaStream;
+    const stream = await this.getInputStream(deviceId);
+    const newAudioTrack = stream.getAudioTracks()[0];
     const sender = this.media.rtcPeerConnection
       .getSenders()
       .find((candidate) => candidate.track?.kind === "audio");
-    if (sender) {
-      await sender.replaceTrack(newAudioTrack);
+    try {
+      if (sender) {
+        await sender.replaceTrack(newAudioTrack);
+      } else {
+        this.addInputTracks(stream);
+      }
+    } catch (error) {
+      for (const track of stream.getTracks()) track.stop();
+      throw error;
+    }
+    this.commitInputStream(deviceId, stream);
+    for (const track of previousStream?.getAudioTracks() ?? []) {
+      track.stop();
     }
   }
 
@@ -145,14 +155,21 @@ class DefaultMediaSession implements MediaSession<DefaultMediaObjects> {
     }
   }
 
-  private async setInputStream(deviceId: string) {
-    this.media.inputDeviceId = deviceId;
-    this.media.mediaStream = await navigator.mediaDevices.getUserMedia({
+  private async getInputStream(deviceId: string) {
+    return await navigator.mediaDevices.getUserMedia({
       video: false,
       audio: { deviceId: { exact: deviceId } },
     });
-    this.context.onMediaStream?.(this.media.mediaStream);
-    this.media.mediaStream.getAudioTracks().forEach((track) => {
+  }
+
+  private commitInputStream(deviceId: string, stream: MediaStream) {
+    this.media.inputDeviceId = deviceId;
+    this.media.mediaStream = stream;
+    this.context.onMediaStream?.(stream);
+  }
+
+  private addInputTracks(stream: MediaStream) {
+    stream.getAudioTracks().forEach((track) => {
       const sender = this.media.rtcPeerConnection.addTrack(track);
       const params = sender.getParameters();
       if (!params.encodings || params.encodings.length === 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export interface MediaSession<M extends object> {
     duration?: number,
     interToneGap?: number,
   ) => Promise<void>;
+  // The SDK does not await provider cleanup. Remote providers own completion,
+  // timeout, and retry behavior after disposal is requested.
   dispose: () => Promise<void>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,16 +3,58 @@ import type InboundMessage from "./sip-message/inbound.js";
 import type RequestMessage from "./sip-message/outbound/request.js";
 import type ResponseMessage from "./sip-message/outbound/response.js";
 
+export interface DefaultMediaObjects {
+  rtcPeerConnection: RTCPeerConnection;
+  mediaStream?: MediaStream;
+  audioElement: HTMLAudioElement;
+  inputDeviceId: string;
+  outputDeviceId?: string;
+}
+
+export interface MediaProviderContext {
+  callId: string;
+  direction: "inbound" | "outbound";
+  iceServers: string[];
+  deviceManager: DeviceManager;
+  onMediaStream?: (stream: MediaStream) => void;
+}
+
+export interface MediaSession<M extends object> {
+  media: M;
+  init: () => Promise<void>;
+  createOffer: (options?: {
+    iceRestart?: boolean;
+    receive?: boolean;
+  }) => Promise<string>;
+  answerOffer: (sdp: string) => Promise<string>;
+  applyAnswer: (sdp: string) => Promise<void>;
+  changeInputDevice: (deviceId: string) => Promise<void>;
+  changeOutputDevice: (deviceId: string) => Promise<void>;
+  setMuted: (muted: boolean) => Promise<void>;
+  sendDtmf: (
+    tones: string,
+    duration?: number,
+    interToneGap?: number,
+  ) => Promise<void>;
+  dispose: () => Promise<void>;
+}
+
+export interface MediaProvider<M extends object = DefaultMediaObjects> {
+  create: (context: MediaProviderContext) => Promise<MediaSession<M>>;
+}
+
 export interface SipClientOptions {
   sipInfo: SipInfo;
   instanceId?: string; // ref: https://docs.oracle.com/cd/E95618_01/html/sbc_scz810_acliconfiguration/GUID-B2A15693-DA4A-4E24-86D4-58B19435F4DA.htm
   debug?: boolean;
 }
 
-export type WebPhoneOptions = SipClientOptions & {
+export type WebPhoneOptions<M extends object = DefaultMediaObjects> =
+  SipClientOptions & {
   sipClient?: SipClient;
   deviceManager?: DeviceManager;
   autoAnswer?: boolean;
+  mediaProvider?: MediaProvider<M>;
 };
 
 export interface SipInfo {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,11 +21,7 @@ export interface MediaProviderContext {
 
 export interface MediaSession<M extends object> {
   media: M;
-  init: () => Promise<void>;
-  createOffer: (options?: {
-    iceRestart?: boolean;
-    receive?: boolean;
-  }) => Promise<string>;
+  createOffer: (options?: { iceRestart?: boolean }) => Promise<string>;
   answerOffer: (sdp: string) => Promise<string>;
   applyAnswer: (sdp: string) => Promise<void>;
   changeInputDevice: (deviceId: string) => Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,13 +49,25 @@ export interface SipClientOptions {
   debug?: boolean;
 }
 
-export type WebPhoneOptions<M extends object = DefaultMediaObjects> =
-  SipClientOptions & {
+type CommonWebPhoneOptions = {
   sipClient?: SipClient;
   deviceManager?: DeviceManager;
   autoAnswer?: boolean;
-  mediaProvider?: MediaProvider<M>;
 };
+
+type IsDefaultMedia<M extends object> = [M] extends [DefaultMediaObjects]
+  ? [DefaultMediaObjects] extends [M]
+    ? true
+    : false
+  : false;
+
+type MediaProviderOption<M extends object> =
+  IsDefaultMedia<M> extends true
+    ? { mediaProvider?: MediaProvider<DefaultMediaObjects> }
+    : { mediaProvider: MediaProvider<M> };
+
+export type WebPhoneOptions<M extends object = DefaultMediaObjects> =
+  SipClientOptions & CommonWebPhoneOptions & MediaProviderOption<M>;
 
 export interface SipInfo {
   authorizationId: string;

--- a/test/default-media-provider.spec.ts
+++ b/test/default-media-provider.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+
+import { DefaultMediaProvider } from "../src/media-provider";
+
+type FakeTrack = { kind: "audio"; stop: () => void; stopped: boolean };
+const track = (): FakeTrack => {
+  const value: FakeTrack = { kind: "audio", stopped: false, stop: () => { value.stopped = true; } };
+  return value;
+};
+const stream = (audioTrack: FakeTrack) => ({
+  getAudioTracks: () => [audioTrack],
+  getTracks: () => [audioTrack],
+}) as unknown as MediaStream;
+
+const setup = async (replaceTrack: (track: FakeTrack) => Promise<void>) => {
+  const tempTrack = track();
+  const firstTrack = track();
+  const nextTrack = track();
+  const failedTrack = track();
+  const streams = [stream(tempTrack), stream(firstTrack), stream(nextTrack), stream(failedTrack)];
+  const sender = {
+    track: firstTrack,
+    replaceTrack: async (value: FakeTrack) => { await replaceTrack(value); sender.track = value; },
+    getParameters: () => ({ encodings: [] }),
+    setParameters: () => Promise.resolve(),
+  };
+  let addTrackCount = 0;
+  class FakePeerConnection {
+    public ontrack: unknown;
+    public addTrack() { addTrackCount += 1; return sender; }
+    public getSenders() { return [sender]; }
+  }
+  Object.defineProperty(globalThis, "RTCPeerConnection", { configurable: true, value: FakePeerConnection });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { mediaDevices: { getUserMedia: async () => streams.shift()! } },
+  });
+  const mediaSession = await new DefaultMediaProvider().create({
+    callId: "call", direction: "inbound", iceServers: [],
+    deviceManager: { getInputDeviceId: async () => "first", getOutputDeviceId: async () => undefined },
+  });
+  await mediaSession.init();
+  return { mediaSession, firstTrack, nextTrack, failedTrack, addTrackCount: () => addTrackCount };
+};
+
+test("reuses one sender when changing input devices", async () => {
+  const fixture = await setup(async () => {});
+  await fixture.mediaSession.changeInputDevice("next");
+  await fixture.mediaSession.changeInputDevice("next-again");
+
+  expect(fixture.addTrackCount()).toBe(1);
+  expect(fixture.firstTrack.stopped).toBe(true);
+  expect(fixture.nextTrack.stopped).toBe(true);
+  expect(fixture.failedTrack.stopped).toBe(false);
+});
+
+test("rolls back a failed input-device replacement", async () => {
+  const fixture = await setup(async () => { throw new Error("replace failed"); });
+
+  await expect(fixture.mediaSession.changeInputDevice("failed")).rejects.toThrow("replace failed");
+
+  expect(fixture.mediaSession.media.inputDeviceId).toBe("first");
+  expect(fixture.firstTrack.stopped).toBe(false);
+  expect(fixture.nextTrack.stopped).toBe(true);
+});

--- a/test/default-media-provider.spec.ts
+++ b/test/default-media-provider.spec.ts
@@ -4,43 +4,77 @@ import { DefaultMediaProvider } from "../src/media-provider";
 
 type FakeTrack = { kind: "audio"; stop: () => void; stopped: boolean };
 const track = (): FakeTrack => {
-  const value: FakeTrack = { kind: "audio", stopped: false, stop: () => { value.stopped = true; } };
+  const value: FakeTrack = {
+    kind: "audio",
+    stopped: false,
+    stop: () => {
+      value.stopped = true;
+    },
+  };
   return value;
 };
-const stream = (audioTrack: FakeTrack) => ({
-  getAudioTracks: () => [audioTrack],
-  getTracks: () => [audioTrack],
-}) as unknown as MediaStream;
+const stream = (audioTrack: FakeTrack) =>
+  ({
+    getAudioTracks: () => [audioTrack],
+    getTracks: () => [audioTrack],
+  }) as unknown as MediaStream;
 
 const setup = async (replaceTrack: (track: FakeTrack) => Promise<void>) => {
   const tempTrack = track();
   const firstTrack = track();
   const nextTrack = track();
   const failedTrack = track();
-  const streams = [stream(tempTrack), stream(firstTrack), stream(nextTrack), stream(failedTrack)];
+  const streams = [
+    stream(tempTrack),
+    stream(firstTrack),
+    stream(nextTrack),
+    stream(failedTrack),
+  ];
   const sender = {
     track: firstTrack,
-    replaceTrack: async (value: FakeTrack) => { await replaceTrack(value); sender.track = value; },
+    replaceTrack: async (value: FakeTrack) => {
+      await replaceTrack(value);
+      sender.track = value;
+    },
     getParameters: () => ({ encodings: [] }),
     setParameters: () => Promise.resolve(),
   };
   let addTrackCount = 0;
   class FakePeerConnection {
     public ontrack: unknown;
-    public addTrack() { addTrackCount += 1; return sender; }
-    public getSenders() { return [sender]; }
+    public addTrack() {
+      addTrackCount += 1;
+      return sender;
+    }
+    public getSenders() {
+      return [sender];
+    }
   }
-  Object.defineProperty(globalThis, "RTCPeerConnection", { configurable: true, value: FakePeerConnection });
+  Object.defineProperty(globalThis, "RTCPeerConnection", {
+    configurable: true,
+    value: FakePeerConnection,
+  });
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
     value: { mediaDevices: { getUserMedia: async () => streams.shift()! } },
   });
   const mediaSession = await new DefaultMediaProvider().create({
-    callId: "call", direction: "inbound", iceServers: [],
-    deviceManager: { getInputDeviceId: async () => "first", getOutputDeviceId: async () => undefined },
+    callId: "call",
+    direction: "inbound",
+    iceServers: [],
+    deviceManager: {
+      getInputDeviceId: async () => "first",
+      getOutputDeviceId: async () => undefined,
+    },
   });
   await mediaSession.init();
-  return { mediaSession, firstTrack, nextTrack, failedTrack, addTrackCount: () => addTrackCount };
+  return {
+    mediaSession,
+    firstTrack,
+    nextTrack,
+    failedTrack,
+    addTrackCount: () => addTrackCount,
+  };
 };
 
 test("reuses one sender when changing input devices", async () => {
@@ -55,9 +89,13 @@ test("reuses one sender when changing input devices", async () => {
 });
 
 test("rolls back a failed input-device replacement", async () => {
-  const fixture = await setup(async () => { throw new Error("replace failed"); });
+  const fixture = await setup(async () => {
+    throw new Error("replace failed");
+  });
 
-  await expect(fixture.mediaSession.changeInputDevice("failed")).rejects.toThrow("replace failed");
+  await expect(
+    fixture.mediaSession.changeInputDevice("failed"),
+  ).rejects.toThrow("replace failed");
 
   expect(fixture.mediaSession.media.inputDeviceId).toBe("first");
   expect(fixture.firstTrack.stopped).toBe(false);

--- a/test/default-media-provider.spec.ts
+++ b/test/default-media-provider.spec.ts
@@ -67,7 +67,6 @@ const setup = async (replaceTrack: (track: FakeTrack) => Promise<void>) => {
       getOutputDeviceId: async () => undefined,
     },
   });
-  await mediaSession.init();
   return {
     mediaSession,
     firstTrack,

--- a/test/media-provider.spec.ts
+++ b/test/media-provider.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+import InboundCallSession from "../src/call-session/inbound";
+import WebPhone from "../src";
+import EventEmitter from "../src/event-emitter";
+import InboundMessage from "../src/sip-message/inbound";
+import type { MediaProvider, MediaSession, SipClient, SipInfo } from "../src/types";
+import type RequestMessage from "../src/sip-message/outbound/request";
+import type ResponseMessage from "../src/sip-message/outbound/response";
+
+type FakeMedia = { marker: string };
+
+class FakeSipClient extends EventEmitter implements SipClient {
+  public async start() {}
+  public async request(_message: RequestMessage) { return new InboundMessage(); }
+  public async reply(_message: ResponseMessage) {}
+  public async dispose() {}
+}
+
+const sipInfo: SipInfo = {
+  authorizationId: "id", domain: "example.com", outboundProxy: "example.com",
+  outboundProxyBackup: "example.com", username: "100", password: "password", stunServers: [],
+};
+
+test("uses provider-defined media without browser objects", async () => {
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" }, init: async () => {}, createOffer: async () => "",
+    answerOffer: async () => "", applyAnswer: async () => {}, changeInputDevice: async () => {},
+    changeOutputDevice: async () => {}, setMuted: async () => {}, sendDtmf: async () => {}, dispose: async () => {},
+  };
+  const mediaProvider: MediaProvider<FakeMedia> = { create: async () => mediaSession };
+  const webPhone = new WebPhone<FakeMedia>({ sipInfo, sipClient: new FakeSipClient(), mediaProvider });
+  const session = new InboundCallSession(webPhone, new InboundMessage("INVITE"));
+
+  await session.init();
+
+  expect(session.media).toEqual({ marker: "remote" });
+  expect(session.rtcPeerConnection).toBeUndefined();
+  expect(session.audioElement).toBeUndefined();
+});

--- a/test/media-provider.spec.ts
+++ b/test/media-provider.spec.ts
@@ -62,9 +62,16 @@ test("keeps legacy media fields writable", async () => {
   session.mediaStream = stream;
   session.inputDeviceId = "input";
 
+  expect(session.mediaStream).toBe(stream);
+  expect(session.inputDeviceId).toBe("input");
+
   await session.init();
 
   expect(emitted).toBe(stream);
+  expect(session.mediaStream).toBeUndefined();
+  expect(session.inputDeviceId).toBeUndefined();
+  mediaSession.media.mediaStream = stream;
   expect(session.mediaStream).toBe(stream);
-  expect(session.inputDeviceId).toBe("input");
+  mediaSession.media.mediaStream = undefined;
+  expect(session.mediaStream).toBeUndefined();
 });

--- a/test/media-provider.spec.ts
+++ b/test/media-provider.spec.ts
@@ -1,12 +1,17 @@
 import { expect, test } from "@playwright/test";
-
-import InboundCallSession from "../src/call-session/inbound";
 import WebPhone from "../src";
+import InboundCallSession from "../src/call-session/inbound";
+import OutboundCallSession from "../src/call-session/outbound";
 import EventEmitter from "../src/event-emitter";
 import InboundMessage from "../src/sip-message/inbound";
-import type { MediaProvider, MediaSession, SipClient, SipInfo } from "../src/types";
 import type RequestMessage from "../src/sip-message/outbound/request";
 import type ResponseMessage from "../src/sip-message/outbound/response";
+import type {
+  MediaProvider,
+  MediaSession,
+  SipClient,
+  SipInfo,
+} from "../src/types";
 
 type FakeMedia = {
   marker: string;
@@ -19,25 +24,48 @@ type FakeMedia = {
 
 class FakeSipClient extends EventEmitter implements SipClient {
   public async start() {}
-  public async request(_message: RequestMessage) { return new InboundMessage(); }
+  public async request(_message: RequestMessage) {
+    return new InboundMessage();
+  }
   public async reply(_message: ResponseMessage) {}
   public async dispose() {}
 }
 
 const sipInfo: SipInfo = {
-  authorizationId: "id", domain: "example.com", outboundProxy: "example.com",
-  outboundProxyBackup: "example.com", username: "100", password: "password", stunServers: [],
+  authorizationId: "id",
+  domain: "example.com",
+  outboundProxy: "example.com",
+  outboundProxyBackup: "example.com",
+  username: "100",
+  password: "password",
+  stunServers: [],
 };
 
 test("uses provider-defined media without browser objects", async () => {
   const mediaSession: MediaSession<FakeMedia> = {
-    media: { marker: "remote" }, init: async () => {}, createOffer: async () => "",
-    answerOffer: async () => "", applyAnswer: async () => {}, changeInputDevice: async () => {},
-    changeOutputDevice: async () => {}, setMuted: async () => {}, sendDtmf: async () => {}, dispose: async () => {},
+    media: { marker: "remote" },
+    init: async () => {},
+    createOffer: async () => "",
+    answerOffer: async () => "",
+    applyAnswer: async () => {},
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {},
   };
-  const mediaProvider: MediaProvider<FakeMedia> = { create: async () => mediaSession };
-  const webPhone = new WebPhone<FakeMedia>({ sipInfo, sipClient: new FakeSipClient(), mediaProvider });
-  const session = new InboundCallSession(webPhone, new InboundMessage("INVITE"));
+  const mediaProvider: MediaProvider<FakeMedia> = {
+    create: async () => mediaSession,
+  };
+  const webPhone = new WebPhone<FakeMedia>({
+    sipInfo,
+    sipClient: new FakeSipClient(),
+    mediaProvider,
+  });
+  const session = new InboundCallSession(
+    webPhone,
+    new InboundMessage("INVITE"),
+  );
 
   await session.init();
 
@@ -48,17 +76,31 @@ test("uses provider-defined media without browser objects", async () => {
 
 test("keeps legacy media fields writable", async () => {
   const mediaSession: MediaSession<FakeMedia> = {
-    media: { marker: "remote" }, init: async () => {}, createOffer: async () => "",
-    answerOffer: async () => "", applyAnswer: async () => {}, changeInputDevice: async () => {},
-    changeOutputDevice: async () => {}, setMuted: async () => {}, sendDtmf: async () => {}, dispose: async () => {},
+    media: { marker: "remote" },
+    init: async () => {},
+    createOffer: async () => "",
+    answerOffer: async () => "",
+    applyAnswer: async () => {},
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {},
   };
   const webPhone = new WebPhone<FakeMedia>({
-    sipInfo, sipClient: new FakeSipClient(), mediaProvider: { create: async () => mediaSession },
+    sipInfo,
+    sipClient: new FakeSipClient(),
+    mediaProvider: { create: async () => mediaSession },
   });
-  const session = new InboundCallSession(webPhone, new InboundMessage("INVITE"));
+  const session = new InboundCallSession(
+    webPhone,
+    new InboundMessage("INVITE"),
+  );
   const stream = {} as MediaStream;
   let emitted: MediaStream | undefined;
-  session.on("mediaStreamSet", (value) => { emitted = value; });
+  session.on("mediaStreamSet", (value) => {
+    emitted = value;
+  });
   session.mediaStream = stream;
   session.inputDeviceId = "input";
 
@@ -74,4 +116,145 @@ test("keeps legacy media fields writable", async () => {
   expect(session.mediaStream).toBe(stream);
   mediaSession.media.mediaStream = undefined;
   expect(session.mediaStream).toBeUndefined();
+});
+
+test("holds without delegating SDP-only negotiation to the media provider", async () => {
+  let createOfferCalls = 0;
+  const requests: RequestMessage[] = [];
+  const sipClient = new FakeSipClient();
+  sipClient.request = async (message: RequestMessage) => {
+    requests.push(message);
+    return new InboundMessage("SIP/2.0 200 OK", {
+      Via: message.headers.Via,
+      CSeq: message.headers.CSeq,
+    });
+  };
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" },
+    init: async () => {},
+    createOffer: async () => {
+      createOfferCalls += 1;
+      return "";
+    },
+    answerOffer: async () =>
+      "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\na=sendrecv\r\n",
+    applyAnswer: async () => {},
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {},
+  };
+  const invite = new InboundMessage("INVITE", {
+    "Call-Id": "call",
+    CSeq: "1 INVITE",
+    From: "<sip:remote@example.com>;tag=remote",
+    To: "<sip:local@example.com>;tag=local",
+  });
+  const webPhone = new WebPhone<FakeMedia>({
+    sipInfo,
+    sipClient,
+    mediaProvider: { create: async () => mediaSession },
+  });
+  const session = new InboundCallSession(webPhone, invite);
+
+  await session.init();
+  await session.handleReInvite(invite);
+  await session.hold();
+
+  expect(createOfferCalls).toBe(0);
+  expect(requests).toHaveLength(1);
+  expect(requests[0].body).toContain("a=sendonly");
+});
+
+test("disposes SDK state when provider cleanup fails", async () => {
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" },
+    init: async () => {},
+    createOffer: async () => "",
+    answerOffer: async () => "",
+    applyAnswer: async () => {},
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {
+      throw new Error("cleanup failed");
+    },
+  };
+  const webPhone = new WebPhone<FakeMedia>({
+    sipInfo,
+    sipClient: new FakeSipClient(),
+    mediaProvider: { create: async () => mediaSession },
+  });
+  const session = new InboundCallSession(
+    webPhone,
+    new InboundMessage("INVITE"),
+  );
+  let disposed = false;
+  session.once("disposed", () => {
+    disposed = true;
+  });
+
+  await session.init();
+  await session.dispose();
+
+  expect(session.state).toBe("disposed");
+  expect(disposed).toBe(true);
+});
+
+test("ACKs an answered outbound call when applying media fails", async () => {
+  let requestCount = 0;
+  let acked = false;
+  const sipClient = new FakeSipClient();
+  sipClient.request = async (message: RequestMessage) => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return new InboundMessage("SIP/2.0 407 Proxy Authentication Required", {
+        "Proxy-Authenticate": 'Digest, nonce="nonce"',
+      });
+    }
+    return new InboundMessage("SIP/2.0 100 Trying", {
+      CSeq: message.headers.CSeq,
+      From: message.headers.From,
+      To: `${message.headers.To};tag=remote`,
+      Via: message.headers.Via,
+    });
+  };
+  sipClient.reply = async (message: ResponseMessage) => {
+    acked = message.headers.CSeq.endsWith(" ACK");
+  };
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" },
+    init: async () => {},
+    createOffer: async () => "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n",
+    answerOffer: async () => "",
+    applyAnswer: async () => {
+      throw new Error("media failed");
+    },
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {},
+  };
+  const webPhone = new WebPhone<FakeMedia>({
+    sipInfo,
+    sipClient,
+    mediaProvider: { create: async () => mediaSession },
+  });
+  const session = new OutboundCallSession(webPhone, "101");
+
+  await session.init();
+  const result = session.call();
+  await new Promise((resolve) => setTimeout(resolve));
+  sipClient.emit(
+    "inboundMessage",
+    new InboundMessage("SIP/2.0 200 OK", {
+      CSeq: session.sipMessage.headers.CSeq,
+    }),
+  );
+
+  await expect(result).resolves.toBe(true);
+  expect(acked).toBe(true);
 });

--- a/test/media-provider.spec.ts
+++ b/test/media-provider.spec.ts
@@ -8,7 +8,14 @@ import type { MediaProvider, MediaSession, SipClient, SipInfo } from "../src/typ
 import type RequestMessage from "../src/sip-message/outbound/request";
 import type ResponseMessage from "../src/sip-message/outbound/response";
 
-type FakeMedia = { marker: string };
+type FakeMedia = {
+  marker: string;
+  mediaStream?: MediaStream;
+  audioElement?: HTMLAudioElement;
+  rtcPeerConnection?: RTCPeerConnection;
+  inputDeviceId?: string;
+  outputDeviceId?: string;
+};
 
 class FakeSipClient extends EventEmitter implements SipClient {
   public async start() {}
@@ -37,4 +44,27 @@ test("uses provider-defined media without browser objects", async () => {
   expect(session.media).toEqual({ marker: "remote" });
   expect(session.rtcPeerConnection).toBeUndefined();
   expect(session.audioElement).toBeUndefined();
+});
+
+test("keeps legacy media fields writable", async () => {
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" }, init: async () => {}, createOffer: async () => "",
+    answerOffer: async () => "", applyAnswer: async () => {}, changeInputDevice: async () => {},
+    changeOutputDevice: async () => {}, setMuted: async () => {}, sendDtmf: async () => {}, dispose: async () => {},
+  };
+  const webPhone = new WebPhone<FakeMedia>({
+    sipInfo, sipClient: new FakeSipClient(), mediaProvider: { create: async () => mediaSession },
+  });
+  const session = new InboundCallSession(webPhone, new InboundMessage("INVITE"));
+  const stream = {} as MediaStream;
+  let emitted: MediaStream | undefined;
+  session.on("mediaStreamSet", (value) => { emitted = value; });
+  session.mediaStream = stream;
+  session.inputDeviceId = "input";
+
+  await session.init();
+
+  expect(emitted).toBe(stream);
+  expect(session.mediaStream).toBe(stream);
+  expect(session.inputDeviceId).toBe("input");
 });

--- a/test/media-provider.spec.ts
+++ b/test/media-provider.spec.ts
@@ -44,7 +44,6 @@ const sipInfo: SipInfo = {
 test("uses provider-defined media without browser objects", async () => {
   const mediaSession: MediaSession<FakeMedia> = {
     media: { marker: "remote" },
-    init: async () => {},
     createOffer: async () => "",
     answerOffer: async () => "",
     applyAnswer: async () => {},
@@ -77,7 +76,6 @@ test("uses provider-defined media without browser objects", async () => {
 test("keeps legacy media fields writable", async () => {
   const mediaSession: MediaSession<FakeMedia> = {
     media: { marker: "remote" },
-    init: async () => {},
     createOffer: async () => "",
     answerOffer: async () => "",
     applyAnswer: async () => {},
@@ -131,7 +129,6 @@ test("holds without delegating SDP-only negotiation to the media provider", asyn
   };
   const mediaSession: MediaSession<FakeMedia> = {
     media: { marker: "remote" },
-    init: async () => {},
     createOffer: async () => {
       createOfferCalls += 1;
       return "";
@@ -167,10 +164,55 @@ test("holds without delegating SDP-only negotiation to the media provider", asyn
   expect(requests[0].body).toContain("a=sendonly");
 });
 
-test("disposes SDK state when provider cleanup fails", async () => {
+test("unholds with the raw SDP after a sendonly re-INVITE", async () => {
+  const requests: RequestMessage[] = [];
+  const sipClient = new FakeSipClient();
+  sipClient.request = async (message: RequestMessage) => {
+    requests.push(message);
+    return new InboundMessage("SIP/2.0 200 OK", {
+      Via: message.headers.Via,
+      CSeq: message.headers.CSeq,
+    });
+  };
   const mediaSession: MediaSession<FakeMedia> = {
     media: { marker: "remote" },
-    init: async () => {},
+    createOffer: async () =>
+      "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\na=sendrecv\r\n",
+    answerOffer: async () => "",
+    applyAnswer: async () => {},
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {},
+  };
+  const invite = new InboundMessage("INVITE", {
+    "Call-Id": "call",
+    CSeq: "1 INVITE",
+    From: "<sip:remote@example.com>;tag=remote",
+    To: "<sip:local@example.com>;tag=local",
+  });
+  const session = new InboundCallSession(
+    new WebPhone<FakeMedia>({
+      sipInfo,
+      sipClient,
+      mediaProvider: { create: async () => mediaSession },
+    }),
+    invite,
+  );
+
+  await session.init();
+  await session.reInvite(false);
+  await session.unhold();
+
+  expect(requests[0].body).toContain("a=sendonly");
+  expect(requests[1].body).toContain("a=sendrecv");
+});
+
+test("retries media creation after initialization fails", async () => {
+  let createCalls = 0;
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" },
     createOffer: async () => "",
     answerOffer: async () => "",
     applyAnswer: async () => {},
@@ -178,7 +220,40 @@ test("disposes SDK state when provider cleanup fails", async () => {
     changeOutputDevice: async () => {},
     setMuted: async () => {},
     sendDtmf: async () => {},
-    dispose: async () => {
+    dispose: async () => {},
+  };
+  const session = new InboundCallSession(
+    new WebPhone<FakeMedia>({
+      sipInfo,
+      sipClient: new FakeSipClient(),
+      mediaProvider: {
+        create: async () => {
+          createCalls += 1;
+          if (createCalls === 1) throw new Error("microphone failed");
+          return mediaSession;
+        },
+      },
+    }),
+    new InboundMessage("INVITE"),
+  );
+
+  await expect(session.init()).rejects.toThrow("microphone failed");
+  await expect(session.init()).resolves.toBeUndefined();
+  expect(createCalls).toBe(2);
+  expect(session.media).toBe(mediaSession.media);
+});
+
+test("disposes SDK state when provider cleanup fails", async () => {
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" },
+    createOffer: async () => "",
+    answerOffer: async () => "",
+    applyAnswer: async () => {},
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: () => {
       throw new Error("cleanup failed");
     },
   };
@@ -197,13 +272,13 @@ test("disposes SDK state when provider cleanup fails", async () => {
   });
 
   await session.init();
-  await session.dispose();
+  expect(session.dispose()).toBeUndefined();
 
   expect(session.state).toBe("disposed");
   expect(disposed).toBe(true);
 });
 
-test("ACKs an answered outbound call when applying media fails", async () => {
+test("ACKs an answered outbound call and emits mediaError when applying media fails", async () => {
   let requestCount = 0;
   let acked = false;
   const sipClient = new FakeSipClient();
@@ -226,7 +301,6 @@ test("ACKs an answered outbound call when applying media fails", async () => {
   };
   const mediaSession: MediaSession<FakeMedia> = {
     media: { marker: "remote" },
-    init: async () => {},
     createOffer: async () => "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n",
     answerOffer: async () => "",
     applyAnswer: async () => {
@@ -244,6 +318,9 @@ test("ACKs an answered outbound call when applying media fails", async () => {
     mediaProvider: { create: async () => mediaSession },
   });
   const session = new OutboundCallSession(webPhone, "101");
+  const mediaError = new Promise<Error>((resolve) => {
+    session.once("mediaError", resolve);
+  });
 
   await session.init();
   const result = session.call();
@@ -257,4 +334,50 @@ test("ACKs an answered outbound call when applying media fails", async () => {
 
   await expect(result).resolves.toBe(true);
   expect(acked).toBe(true);
+  await expect(mediaError).resolves.toHaveProperty("message", "media failed");
+});
+
+test("ACKs a re-INVITE before surfacing an answer failure", async () => {
+  const order: string[] = [];
+  const sipClient = new FakeSipClient();
+  sipClient.request = async (message: RequestMessage) =>
+    new InboundMessage("SIP/2.0 200 OK", {
+      Via: message.headers.Via,
+      CSeq: message.headers.CSeq,
+    });
+  sipClient.reply = async () => {
+    order.push("ACK");
+  };
+  const mediaSession: MediaSession<FakeMedia> = {
+    media: { marker: "remote" },
+    createOffer: async () => "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\n",
+    answerOffer: async () => "",
+    applyAnswer: async () => {
+      order.push("answer");
+      throw new Error("media failed");
+    },
+    changeInputDevice: async () => {},
+    changeOutputDevice: async () => {},
+    setMuted: async () => {},
+    sendDtmf: async () => {},
+    dispose: async () => {},
+  };
+  const invite = new InboundMessage("INVITE", {
+    "Call-Id": "call",
+    CSeq: "1 INVITE",
+    From: "<sip:remote@example.com>;tag=remote",
+    To: "<sip:local@example.com>;tag=local",
+  });
+  const session = new InboundCallSession(
+    new WebPhone<FakeMedia>({
+      sipInfo,
+      sipClient,
+      mediaProvider: { create: async () => mediaSession },
+    }),
+    invite,
+  );
+
+  await session.init();
+  await expect(session.reInvite()).rejects.toThrow("media failed");
+  expect(order).toEqual(["ACK", "answer"]);
 });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".."
+  },
+  "include": ["webphone-options.typecheck.ts"]
+}

--- a/test/webphone-options.typecheck.ts
+++ b/test/webphone-options.typecheck.ts
@@ -1,4 +1,5 @@
 import WebPhone from "../src/index.js";
+import type InboundCallSession from "../src/call-session/inbound.js";
 import type { MediaProvider, SipInfo } from "../src/types.js";
 
 type RemoteMedia = { hostingTabId: string };
@@ -8,6 +9,11 @@ declare const mediaProvider: MediaProvider<RemoteMedia>;
 
 new WebPhone({ sipInfo });
 new WebPhone<RemoteMedia>({ sipInfo, mediaProvider });
+
+declare const callSession: InboundCallSession<RemoteMedia>;
+
+// @ts-expect-error Provider-owned media is read-only to consumers.
+callSession.media!.hostingTabId = "another-tab";
 
 // @ts-expect-error Custom media requires a matching provider.
 new WebPhone<RemoteMedia>({ sipInfo });

--- a/test/webphone-options.typecheck.ts
+++ b/test/webphone-options.typecheck.ts
@@ -1,0 +1,13 @@
+import WebPhone from "../src/index.js";
+import type { MediaProvider, SipInfo } from "../src/types.js";
+
+type RemoteMedia = { hostingTabId: string };
+
+declare const sipInfo: SipInfo;
+declare const mediaProvider: MediaProvider<RemoteMedia>;
+
+new WebPhone({ sipInfo });
+new WebPhone<RemoteMedia>({ sipInfo, mediaProvider });
+
+// @ts-expect-error Custom media requires a matching provider.
+new WebPhone<RemoteMedia>({ sipInfo });


### PR DESCRIPTION
## Summary

Adds a configurable media-provider boundary to WebPhone.

The default in-process browser provider preserves existing browser behavior.
Custom providers can host media outside the SDK runtime while WebPhone continues
to own SIP dialogs, call state, and lifecycle.

## Changes

- Add generic media-provider and media-session contracts.
- Move browser WebRTC, microphone, playback, SDP/ICE, DTMF, and cleanup logic
  into the default media provider.
- Expose provider-defined state through `callSession.media`.
- Keep existing browser media fields compatible for the default provider.
- Make media commands awaitable for remote-provider support.
- Preserve CommonJS default import behavior.
- Prevent duplicate audio senders during input-device changes.
- Roll back safely if microphone track replacement fails.

## Verification

- `pnpm build`
- Focused media-provider regression tests
