### PR TITLE
Add Call-ID-scoped inbound messages to Call Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,6 +764,20 @@ at the time that you get the `callSession` object, `callSession.mediaStream` is
 already set. It would be too late to subscribe for `mediaStreamSet` event. In
 such case you can access `callSession.mediaStream` directly.
 
+#### `inboundMessage` event
+
+This event receives the original inbound SIP message when its exact,
+case-sensitive Call-ID matches this live Call Session. Full Call-ID header names
+are matched case-insensitively; From and To tags do not affect the match. The
+initial inbound INVITE is not replayed, while later matching messages, including
+terminal messages, are eligible.
+
+```ts
+callSession.on("inboundMessage", (message) => {
+  console.log("Received a message for this Call Session:", message.subject);
+});
+```
+
 #### Where is the `ringing` event?
 
 `ringing` event is implicit.
@@ -823,10 +837,11 @@ this.webPhone.call(toNumber, this.fromNumber);
 - `inboundMessage`
 - `outboundMessage`
 
-These events represent low-level SIP messages received from or sent to the SIP
-server by the web phone instance. Most developers won’t need to interact with
-these directly, but they’re exposed for advanced use cases that require greater
-flexibility.
+These global events represent every low-level SIP message received from or sent
+to the SIP server by the web phone instance. Unlike
+`callSession.inboundMessage`, `sipClient.inboundMessage` is not scoped to one
+Call-ID. Most developers won’t need to interact with these directly, but they’re
+exposed for advanced use cases that require greater flexibility.
 
 **Example:**
 

--- a/docs/events/inboundMessage.md
+++ b/docs/events/inboundMessage.md
@@ -1,49 +1,36 @@
-# callSession.on(`inboundMessage`, callback)
+# inboundMessage
 
-Registers a callback function to be invoked when a new inbound SIP message is
-received over the WebSocket connection.
+The SIP Client and Call Session expose the same raw `InboundMessage` object at
+different scopes:
 
-The inboundMessage event is emitted whenever the SIP client receives an inbound
-SIP message from the server. This includes various SIP methods such as INVITE,
-BYE, CANCEL, INFO, NOTIFY, and MESSAGE.
+| Subscription | Scope |
+| --- | --- |
+| `webPhone.sipClient.on("inboundMessage", callback)` | Every inbound SIP message received by the SIP Client. |
+| `callSession.on("inboundMessage", callback)` | Inbound SIP messages whose exact, case-sensitive Call-ID value matches that live Call Session. |
 
-This event provides access to the raw SIP message, allowing developers to handle
-custom SIP interactions or monitor SIP traffic for debugging and analytics
-purposes.
+Call-ID header names use the normal case-insensitive SIP header matching, so
+`Call-Id`, `Call-ID`, and `call-id` are supported. The compact `i` header is not
+supported. From and To tags do not affect the match.
 
-## Callback Parameters
+The initial inbound INVITE creates its Call Session and is not replayed on the
+scoped event. Later matching messages, including terminal messages, are
+eligible.
 
-The callback function receives a single parameter:
+## Global SIP Client feed
 
-| Parameter | Type             | Description                                                                                               |
-| --------- | ---------------- | --------------------------------------------------------------------------------------------------------- |
-| `message` | `InboundMessage` | An object representing the inbound SIP message, containing properties such as subject, headers, and body. |
-
-## Usage Example
-
-```js
-sipClient.on("inboundMessage", (message) => {
-  console.log("Received SIP message:", message.subject);
-  // Custom handling based on message type
-  if (message.subject.startsWith("MESSAGE sip:")) {
-    // Handle SIP MESSAGE
-  }
+```ts
+webPhone.sipClient.on("inboundMessage", (message) => {
+  console.log("Received an inbound SIP message:", message.subject);
 });
 ```
 
-## Notes
+## Call-ID-scoped Call Session feed
 
-- **Automatic 200 OK Responses**: For certain SIP methods (MESSAGE, BYE, CANCEL,
-  INFO, and NOTIFY), the SIP client automatically sends a 200 OK response upon
-  receiving the message. This behavior ensures compliance with SIP protocol
-  expectations and reduces the need for manual acknowledgment.
+```ts
+callSession.on("inboundMessage", (message) => {
+  console.log("Received a message for this Call Session:", message.subject);
+});
+```
 
-- **Message Filtering**: The SIP client includes logic to filter out messages
-  not intended for the current instance, based on the `Cln` (Client ID) field in
-  the message body. If the `Cln` does not match the client's authorization ID,
-  the message is ignored.
-
-- **Debugging**: If the SIP client is initialized with
-  [debugging enabled](../get-started/instances.md#turning-on-debug-mode) (debug:
-  true), incoming messages are logged to the console, providing visibility into
-  SIP traffic for troubleshooting purposes.
+Both callbacks receive the original `InboundMessage`, with its `subject`,
+`headers`, and `body`.

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -35,6 +35,12 @@ callSession.on("disposed", () => {
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`answered`](answered.md)               | Triggered when the call is answered.                                                                                                                                       |
 | [`disposed`](disposed.md)               | For answered calls, this event is triggered when someone hangs up. For inbound calls, it is triggered if the caller hangs up or if the call is answered on another device. |
-| [`inboundMessage`](inboundMessage.md)   | Triggered when you receive a SIP message.                                                                                                                                  |
-| [`outboundMessage`](outboundMessage.md) | Triggered when a SIP message is sent.                                                                                                                                      |
+| [`inboundMessage`](inboundMessage.md)   | Triggered for inbound SIP messages with the same exact Call-ID as this live Call Session.                                                                                  |
 | [`ringing`](ringing.md)                 | This event does exist, but it is effectively implied by the existence of other events.                                                                                     |
+
+## SIP Client events
+
+| Event                                   | Description                                                  |
+| --------------------------------------- | ------------------------------------------------------------ |
+| [`inboundMessage`](inboundMessage.md)   | Triggered for every inbound SIP message received by the SIP Client. |
+| [`outboundMessage`](outboundMessage.md) | Triggered when the SIP Client sends a SIP message.            |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -91,6 +91,8 @@ nav:
           - "disposed": events/disposed.md
           - "inboundMessage": events/inboundMessage.md
           - "ringing": events/ringing.md
+      - "SIP Client events":
+          - "inboundMessage": events/inboundMessage.md
           - "outboundMessage": events/outboundMessage.md
   - "Reference":
       - "Overview": reference/index.md

--- a/src/call-session/inbound.ts
+++ b/src/call-session/inbound.ts
@@ -195,12 +195,12 @@ class InboundCallSession extends CallSession {
             rcMessage.headers.Cmd ===
             callControlCommands.AlreadyProcessed.toString()
           ) {
-            this.off("inboundMessage", handler);
+            this.webPhone.sipClient.off("inboundMessage", handler);
             resolve();
           }
         }
       };
-      this.on("inboundMessage", handler);
+      this.webPhone.sipClient.on("inboundMessage", handler);
     });
   }
 

--- a/src/call-session/inbound.ts
+++ b/src/call-session/inbound.ts
@@ -131,6 +131,7 @@ class InboundCallSession extends CallSession {
     if (Object.values(body).some((value) => value === undefined)) {
       throw new Error("Invalid reply options");
     }
+    const sid = RcMessage.fromXml(this.sipMessage.headers["P-rc"]).headers.SID;
     await this.sendRcMessage(callControlCommands.ClientReply, body);
     return new Promise((resolve) => {
       const sessionCloseHandler = async (inboundMessage: InboundMessage) => {
@@ -138,15 +139,16 @@ class InboundCallSession extends CallSession {
           const rcMessage = await RcMessage.fromXml(inboundMessage.body);
           if (
             rcMessage.headers.Cmd ===
-            callControlCommands.SessionClose.toString()
+              callControlCommands.SessionClose.toString() &&
+            rcMessage.headers.SID === sid
           ) {
-            this.off("inboundMessage", sessionCloseHandler);
+            this.webPhone.sipClient.off("inboundMessage", sessionCloseHandler);
             resolve(rcMessage);
             // no need to dispose session here, session will dispose unpon CANCEL or BYE
           }
         }
       };
-      this.on("inboundMessage", sessionCloseHandler);
+      this.webPhone.sipClient.on("inboundMessage", sessionCloseHandler);
     });
   }
 
@@ -185,23 +187,6 @@ class InboundCallSession extends CallSession {
 
     this.state = "answered";
     this.emit("answered");
-
-    // wait for the final SIP message
-    return new Promise<void>((resolve) => {
-      const handler = async (inboundMessage: InboundMessage) => {
-        if (inboundMessage.subject.startsWith("MESSAGE sip:")) {
-          const rcMessage = await RcMessage.fromXml(inboundMessage.body);
-          if (
-            rcMessage.headers.Cmd ===
-            callControlCommands.AlreadyProcessed.toString()
-          ) {
-            this.webPhone.sipClient.off("inboundMessage", handler);
-            resolve();
-          }
-        }
-      };
-      this.webPhone.sipClient.on("inboundMessage", handler);
-    });
   }
 
   protected async sendRcMessage(

--- a/src/call-session/inbound.ts
+++ b/src/call-session/inbound.ts
@@ -103,11 +103,11 @@ class InboundCallSession extends CallSession {
     return new Promise<void>((resolve) => {
       const handler = (inboundMessage: InboundMessage) => {
         if (inboundMessage.subject.startsWith("CANCEL sip:")) {
-          this.webPhone.sipClient.off("inboundMessage", handler);
+          this.off("inboundMessage", handler);
           resolve();
         }
       };
-      this.webPhone.sipClient.on("inboundMessage", handler);
+      this.on("inboundMessage", handler);
     });
   }
 
@@ -140,13 +140,13 @@ class InboundCallSession extends CallSession {
             rcMessage.headers.Cmd ===
             callControlCommands.SessionClose.toString()
           ) {
-            this.webPhone.sipClient.off("inboundMessage", sessionCloseHandler);
+            this.off("inboundMessage", sessionCloseHandler);
             resolve(rcMessage);
             // no need to dispose session here, session will dispose unpon CANCEL or BYE
           }
         }
       };
-      this.webPhone.sipClient.on("inboundMessage", sessionCloseHandler);
+      this.on("inboundMessage", sessionCloseHandler);
     });
   }
 
@@ -195,12 +195,12 @@ class InboundCallSession extends CallSession {
             rcMessage.headers.Cmd ===
             callControlCommands.AlreadyProcessed.toString()
           ) {
-            this.webPhone.sipClient.off("inboundMessage", handler);
+            this.off("inboundMessage", handler);
             resolve();
           }
         }
       };
-      this.webPhone.sipClient.on("inboundMessage", handler);
+      this.on("inboundMessage", handler);
     });
   }
 

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -526,10 +526,10 @@ class CallSession extends EventEmitter {
         ) {
           return;
         }
-        this.webPhone.sipClient.off("inboundMessage", resultHandler);
+        this.off("inboundMessage", resultHandler);
         resolve(response.result);
       };
-      this.webPhone.sipClient.on("inboundMessage", resultHandler);
+      this.on("inboundMessage", resultHandler);
     });
   }
 
@@ -554,17 +554,14 @@ class CallSession extends EventEmitter {
     let timeoutId: ReturnType<typeof setTimeout>;
     return new Promise<void>((resolve, reject) => {
       const handler = (inboundMessage: InboundMessage) => {
-        if (
-          inboundMessage.subject.startsWith("BYE sip:") &&
-          inboundMessage.headers["Call-Id"] === this.callId
-        ) {
+        if (inboundMessage.subject.startsWith("BYE sip:")) {
           clearTimeout(timeoutId);
-          this.webPhone.sipClient.off("inboundMessage", handler);
+          this.off("inboundMessage", handler);
           resolve();
         }
       };
       timeoutId = setTimeout(() => {
-        this.webPhone.sipClient.off("inboundMessage", handler);
+        this.off("inboundMessage", handler);
         reject(
           new Error(
             `"REFER ${extractAddress(
@@ -573,7 +570,7 @@ class CallSession extends EventEmitter {
           ),
         );
       }, timeout);
-      this.webPhone.sipClient.on("inboundMessage", handler);
+      this.on("inboundMessage", handler);
     });
   }
 }

--- a/src/call-session/index.ts
+++ b/src/call-session/index.ts
@@ -10,6 +10,7 @@ import {
   extractNumber,
   extractTag,
   fakeDomain,
+  getHeader,
   uuid,
 } from "../utils.js";
 import type OutboundCallSession from "./outbound.js";
@@ -69,7 +70,9 @@ class CallSession extends EventEmitter {
   // for outbound call, this._callId will be the call id. Once the call session is out of "init" state, this.sipMessage will be set
   private _callId = uuid();
   public get callId() {
-    return this.sipMessage?.headers["Call-Id"] ?? this._callId;
+    return this.sipMessage
+      ? (getHeader(this.sipMessage.headers, "Call-Id") ?? this._callId)
+      : this._callId;
   }
 
   public get sessionId() {

--- a/src/call-session/outbound.ts
+++ b/src/call-session/outbound.ts
@@ -78,7 +78,7 @@ class OutboundCallSession extends CallSession {
     return new Promise<boolean>((resolve) => {
       const answerHandler = async (message: InboundMessage) => {
         if (message.headers.CSeq === this.sipMessage.headers.CSeq) {
-          this.webPhone.sipClient.off("inboundMessage", answerHandler);
+          this.off("inboundMessage", answerHandler);
 
           // outbound call failed, for example, invalid number
           // or emergency address is not configured properly
@@ -114,7 +114,7 @@ class OutboundCallSession extends CallSession {
           resolve(true);
         }
       };
-      this.webPhone.sipClient.on("inboundMessage", answerHandler);
+      this.on("inboundMessage", answerHandler);
     });
   }
 

--- a/src/call-session/outbound.ts
+++ b/src/call-session/outbound.ts
@@ -85,10 +85,7 @@ class OutboundCallSession extends CallSession {
           if (message.subject !== "SIP/2.0 200 OK") {
             this.state = "failed";
             this.emit("failed", message.subject);
-            const index = this.webPhone.callSessions.findIndex(
-              (callSession) =>
-                callSession.callId === message.headers["Call-Id"],
-            );
+            const index = this.webPhone.callSessions.indexOf(this);
             if (index !== -1) {
               this.webPhone.callSessions.splice(index, 1);
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type {
   SipInfo,
   WebPhoneOptions,
 } from "./types.js";
+import { getHeader } from "./utils.js";
 
 class WebPhone extends EventEmitter {
   public sipInfo: SipInfo;
@@ -34,6 +35,12 @@ class WebPhone extends EventEmitter {
     this.sipClient.on(
       "inboundMessage",
       async (inboundMessage: InboundMessage) => {
+        const scopedCallSession = this.callSessions.find(
+          (callSession) =>
+            callSession.callId === getHeader(inboundMessage.headers, "Call-Id"),
+        );
+        scopedCallSession?.emit("inboundMessage", inboundMessage);
+
         // either inbound BYE/CANCEL or server reply to outbound BYE/CANCEL
         if (
           inboundMessage.headers.CSeq.endsWith(" BYE") ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,10 +46,9 @@ class WebPhone extends EventEmitter {
           inboundMessage.headers.CSeq.endsWith(" BYE") ||
           inboundMessage.headers.CSeq.endsWith(" CANCEL")
         ) {
-          const index = this.callSessions.findIndex(
-            (callSession) =>
-              callSession.callId === inboundMessage.headers["Call-Id"],
-          );
+          const index = scopedCallSession
+            ? this.callSessions.indexOf(scopedCallSession)
+            : -1;
           if (index !== -1) {
             const callSession = this.callSessions[index];
             this.callSessions.splice(index, 1);

--- a/src/sip-client.ts
+++ b/src/sip-client.ts
@@ -10,14 +10,11 @@ import {
   fakeDomain,
   fakeEmail,
   generateAuthorization,
+  getHeader,
   uuid,
 } from "./utils.js";
 
 const maxExpires = 60;
-const getHeader = (headers: Record<string, string>, name: string) =>
-  Object.entries(headers).find(
-    ([key]) => key.toLowerCase() === name.toLowerCase(),
-  )?.[1];
 const autoReplyPattern = /^(MESSAGE|BYE|CANCEL|INFO|NOTIFY|UPDATE) sip:/;
 
 export class DefaultSipClient extends EventEmitter implements SipClient {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,11 @@ export const uuid = () => {
 
 export const branch = () => "z9hG4bK-" + uuid();
 
+export const getHeader = (headers: Record<string, string>, name: string) =>
+  Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === name.toLowerCase(),
+  )?.[1];
+
 const generateResponse = (
   sipInfo: SipInfo,
   endpoint: string,

--- a/test/common.ts
+++ b/test/common.ts
@@ -173,6 +173,7 @@ export const callAndAnswer = async (
   await calleePage.evaluate(async () => {
     await globalThis.inboundCalls[0].answer();
   });
+  await expect.poll(() => calleeMessages).toHaveLength(4);
   callerMessages.length = 0;
   calleeMessages.length = 0;
   return { callerPage, calleePage, callerMessages, calleeMessages };

--- a/test/inbound-reply-options.spec.ts
+++ b/test/inbound-reply-options.spec.ts
@@ -20,11 +20,11 @@ const sipInfo: SipInfo = {
   stunServers: [],
 };
 
-const sessionCloseMessage = () =>
+const sessionCloseMessage = (callId: string, status: string) =>
   new InboundMessage(
     "MESSAGE sip:100@example.com SIP/2.0",
-    { CSeq: "2 MESSAGE" },
-    new RcMessage({ Cmd: "9" }, {}).toXml(),
+    { CSeq: "2 MESSAGE", "Call-Id": callId },
+    new RcMessage({ Cmd: "9" }, { Sts: status }).toXml(),
   );
 
 class FakeSipClient extends EventEmitter implements SipClient {
@@ -33,7 +33,10 @@ class FakeSipClient extends EventEmitter implements SipClient {
   public async start() {}
   public async request(message: RequestMessage) {
     this.requests.push(message);
-    setTimeout(() => this.emit("inboundMessage", sessionCloseMessage()));
+    setTimeout(() => {
+      this.emit("inboundMessage", sessionCloseMessage("other-call", "wrong"));
+      this.emit("inboundMessage", sessionCloseMessage("call-id", "complete"));
+    });
     return new InboundMessage("SIP/2.0 200 OK", { CSeq: "1 MESSAGE" });
   }
   public async reply(_message: ResponseMessage) {}
@@ -54,10 +57,9 @@ const createSession = () => {
       {},
     ).toXml(),
   });
-  return {
-    session: new InboundCallSession(webPhone, invite),
-    sipClient,
-  };
+  const session = new InboundCallSession(webPhone, invite);
+  webPhone.callSessions.push(session);
+  return { session, sipClient };
 };
 
 const sendReply = async (arg: string | ReplyOptions) => {
@@ -95,6 +97,7 @@ test("reply translates developer options to RC wire fields", async () => {
     const { body, response } = await sendReply(options);
     expect(body).toEqual(expectedBody);
     expect(response.headers.Cmd).toBe("9");
+    expect(response.body.Sts).toBe("complete");
   }
 });
 

--- a/test/inbound-reply-options.spec.ts
+++ b/test/inbound-reply-options.spec.ts
@@ -20,11 +20,11 @@ const sipInfo: SipInfo = {
   stunServers: [],
 };
 
-const sessionCloseMessage = (callId: string, status: string) =>
+const sessionCloseMessage = (callId: string, sid: string, status: string) =>
   new InboundMessage(
     "MESSAGE sip:100@example.com SIP/2.0",
     { CSeq: "2 MESSAGE", "Call-Id": callId },
-    new RcMessage({ Cmd: "9" }, { Sts: status }).toXml(),
+    new RcMessage({ SID: sid, Cmd: "9" }, { Sts: status }).toXml(),
   );
 
 class FakeSipClient extends EventEmitter implements SipClient {
@@ -34,8 +34,14 @@ class FakeSipClient extends EventEmitter implements SipClient {
   public async request(message: RequestMessage) {
     this.requests.push(message);
     setTimeout(() => {
-      this.emit("inboundMessage", sessionCloseMessage("other-call", "wrong"));
-      this.emit("inboundMessage", sessionCloseMessage("call-id", "complete"));
+      this.emit(
+        "inboundMessage",
+        sessionCloseMessage("call-id", "other-sid", "wrong"),
+      );
+      this.emit(
+        "inboundMessage",
+        sessionCloseMessage("other-call", "sid", "complete"),
+      );
     });
     return new InboundMessage("SIP/2.0 200 OK", { CSeq: "1 MESSAGE" });
   }

--- a/test/inbound/answer.spec.ts
+++ b/test/inbound/answer.spec.ts
@@ -18,6 +18,7 @@ testTwoPages(
     await assertCallCount(callerPage, 1);
 
     // callee
+    await expect.poll(() => calleeMessages).toHaveLength(4);
     const messages = calleeMessages.map((m) => m.shortString);
     expect(messages).toHaveLength(4);
     expect(messages[0]).toMatch(/^outbound - SIP\/2.0 200 OK$/);

--- a/test/web-rtc-session.spec.ts
+++ b/test/web-rtc-session.spec.ts
@@ -122,23 +122,6 @@ const inboundInvite = (body = REMOTE_OFFER, callId = "call-id") =>
     body,
   );
 
-const alreadyProcessedMessage = (callId = "call-id") =>
-  new InboundMessage(
-    "MESSAGE sip:100@example.com SIP/2.0",
-    { CSeq: "2 MESSAGE", "Call-Id": callId },
-    new RcMessage({ Cmd: "7" }, {}).toXml(),
-  );
-
-const completeInboundAnswer = async (
-  sipClient: FakeSipClient,
-  answer: Promise<void>,
-  callId = "call-id",
-) => {
-  await expect.poll(() => sipClient.replies.length).toBe(1);
-  sipClient.emit("inboundMessage", alreadyProcessedMessage(callId));
-  await answer;
-};
-
 test("projects inbound SIP messages onto the matching live Call Session", async () => {
   const sipClient = new FakeSipClient();
   const webPhone = new WebPhone({ sipInfo, sipClient, autoAnswer: false });
@@ -302,7 +285,7 @@ test("delegates inbound offer and offerless call negotiation", async () => {
   webPhone.callSessions.push(offered);
   const offeredAnswer = offered.answer();
 
-  await completeInboundAnswer(sipClient, offeredAnswer);
+  await expect(offeredAnswer).resolves.toBeUndefined();
 
   expect(offeredWebRtc.offerAnswers).toEqual([offered.sipMessage.body]);
   expect(sipClient.replies[0].body).toBe(`${LOCAL_SDP}\r\n`);
@@ -329,7 +312,6 @@ test("delegates inbound offer and offerless call negotiation", async () => {
   await expect.poll(() => offerless.state).toBe("answered");
   expect(offerlessWebRtc.offers).toEqual([{ iceRestart: true }]);
   expect(offerlessWebRtc.appliedAnswers).toEqual([NORMALIZED_REMOTE_ANSWER]);
-  sipClient.emit("inboundMessage", alreadyProcessedMessage("other-call"));
   await offerlessAnswer;
 });
 

--- a/test/web-rtc-session.spec.ts
+++ b/test/web-rtc-session.spec.ts
@@ -134,6 +134,72 @@ const completeInboundAnswer = async (
   await answer;
 };
 
+test("projects inbound SIP messages onto the matching live Call Session", async () => {
+  const sipClient = new FakeSipClient();
+  const webPhone = new WebPhone({ sipInfo, sipClient, autoAnswer: false });
+  const globalMessages: InboundMessage[] = [];
+  sipClient.on("inboundMessage", (message) => globalMessages.push(message));
+
+  const invite = inboundInvite();
+  const callId = invite.headers["Call-Id"];
+  invite.headers["Call-ID"] = callId;
+  delete invite.headers["Call-Id"];
+  sipClient.emit("inboundMessage", invite);
+  const session = webPhone.callSessions[0];
+  expect(session.callId).toBe(callId);
+  const scopedMessages: InboundMessage[] = [];
+  session.on("inboundMessage", (message) => scopedMessages.push(message));
+
+  await expect.poll(() => sipClient.replies).toHaveLength(2);
+  expect(scopedMessages).toEqual([]);
+
+  for (const [index, header] of ["Call-Id", "Call-ID", "call-id"].entries()) {
+    const message = new InboundMessage("INFO sip:100@example.com SIP/2.0", {
+      CSeq: `${index + 2} INFO`,
+      From: `<sip:101@example.com>;tag=other-${index}`,
+      To: `<sip:100@example.com>;tag=different-${index}`,
+      [header]: callId,
+    });
+    sipClient.emit("inboundMessage", message);
+    expect(scopedMessages.at(-1)).toBe(message);
+  }
+
+  for (const headers of [
+    { "Call-Id": callId.toUpperCase() },
+    { CSeq: "5 INFO" },
+    { i: callId },
+  ]) {
+    sipClient.emit(
+      "inboundMessage",
+      new InboundMessage("INFO sip:100@example.com SIP/2.0", {
+        CSeq: "5 INFO",
+        ...headers,
+      }),
+    );
+  }
+  expect(scopedMessages).toHaveLength(3);
+
+  const bye = new InboundMessage("BYE sip:100@example.com SIP/2.0", {
+    CSeq: "6 BYE",
+    "Call-Id": callId,
+  });
+  sipClient.emit("inboundMessage", bye);
+  expect(scopedMessages.at(-1)).toBe(bye);
+  expect(scopedMessages).toHaveLength(4);
+  expect(webPhone.callSessions).toEqual([]);
+
+  sipClient.emit(
+    "inboundMessage",
+    new InboundMessage("INFO sip:100@example.com SIP/2.0", {
+      CSeq: "7 INFO",
+      "Call-Id": callId,
+    }),
+  );
+  expect(scopedMessages).toHaveLength(4);
+  expect(globalMessages[0]).toBe(invite);
+  expect(globalMessages).toHaveLength(9);
+});
+
 test("delegates an outbound call without browser WebRTC globals", async () => {
   const sipClient = new FakeSipClient();
   const webRtcSession = new FakeWebRtcSession();

--- a/test/web-rtc-session.spec.ts
+++ b/test/web-rtc-session.spec.ts
@@ -105,7 +105,7 @@ class FakeWebRtcSession implements WebRtcSession {
   }
 }
 
-const inboundInvite = (body = REMOTE_OFFER) =>
+const inboundInvite = (body = REMOTE_OFFER, callId = "call-id") =>
   new InboundMessage(
     "INVITE sip:100@example.com SIP/2.0",
     {
@@ -113,24 +113,29 @@ const inboundInvite = (body = REMOTE_OFFER) =>
       CSeq: "1 INVITE",
       From: "<sip:101@example.com>;tag=remote",
       To: "<sip:100@example.com>;tag=local",
-      "Call-Id": "call-id",
+      "Call-Id": callId,
+      "P-rc": new RcMessage(
+        { SID: "sid", Req: "req", From: "101", To: "100" },
+        {},
+      ).toXml(),
     },
     body,
   );
 
-const alreadyProcessedMessage = () =>
+const alreadyProcessedMessage = (callId = "call-id") =>
   new InboundMessage(
     "MESSAGE sip:100@example.com SIP/2.0",
-    { CSeq: "2 MESSAGE" },
+    { CSeq: "2 MESSAGE", "Call-Id": callId },
     new RcMessage({ Cmd: "7" }, {}).toXml(),
   );
 
 const completeInboundAnswer = async (
   sipClient: FakeSipClient,
   answer: Promise<void>,
+  callId = "call-id",
 ) => {
   await expect.poll(() => sipClient.replies.length).toBe(1);
-  sipClient.emit("inboundMessage", alreadyProcessedMessage());
+  sipClient.emit("inboundMessage", alreadyProcessedMessage(callId));
   await answer;
 };
 
@@ -221,9 +226,19 @@ test("delegates an outbound call without browser WebRTC globals", async () => {
     setTimeout(() => {
       sipClient.emit(
         "inboundMessage",
+        new InboundMessage("SIP/2.0 486 Busy Here", {
+          CSeq: progress.headers.CSeq,
+          "Call-Id": "other-call",
+        }),
+      );
+      sipClient.emit(
+        "inboundMessage",
         new InboundMessage(
           "SIP/2.0 200 OK",
-          { CSeq: progress.headers.CSeq },
+          {
+            CSeq: progress.headers.CSeq,
+            "Call-Id": message.headers["Call-Id"],
+          },
           REMOTE_ANSWER,
         ),
       );
@@ -284,6 +299,7 @@ test("delegates inbound offer and offerless call negotiation", async () => {
     webRtcSessionFactory: () => sessions.shift() as WebRtcSession,
   });
   const offered = new InboundCallSession(webPhone, inboundInvite());
+  webPhone.callSessions.push(offered);
   const offeredAnswer = offered.answer();
 
   await completeInboundAnswer(sipClient, offeredAnswer);
@@ -298,17 +314,175 @@ test("delegates inbound offer and offerless call negotiation", async () => {
       {
         Via: message.headers.Via,
         CSeq: message.headers.CSeq.replace(" INVITE", " ACK"),
+        "Call-Id": message.headers["Call-Id"],
       },
       REMOTE_ANSWER,
     );
-  const offerless = new InboundCallSession(webPhone, inboundInvite(""));
+  webPhone.callSessions.length = 0;
+  const offerless = new InboundCallSession(
+    webPhone,
+    inboundInvite("", "offerless-call"),
+  );
+  webPhone.callSessions.push(offerless);
   const offerlessAnswer = offerless.answer();
 
   await expect.poll(() => offerless.state).toBe("answered");
   expect(offerlessWebRtc.offers).toEqual([{ iceRestart: true }]);
   expect(offerlessWebRtc.appliedAnswers).toEqual([NORMALIZED_REMOTE_ANSWER]);
-  sipClient.emit("inboundMessage", alreadyProcessedMessage());
+  sipClient.emit("inboundMessage", alreadyProcessedMessage("other-call"));
+  let completed = false;
+  void offerlessAnswer.then(() => {
+    completed = true;
+  });
+  await new Promise((resolve) => setTimeout(resolve));
+  expect(completed).toBe(false);
+  sipClient.emit("inboundMessage", alreadyProcessedMessage("offerless-call"));
   await offerlessAnswer;
+});
+
+test("correlates JSON command results on the Call Session", async () => {
+  const sipClient = new FakeSipClient();
+  const webPhone = new WebPhone({ sipInfo, sipClient });
+  const session = new InboundCallSession(webPhone, inboundInvite());
+  webPhone.callSessions.push(session);
+
+  const resultPromise = session.startRecording();
+  await expect.poll(() => sipClient.requests).toHaveLength(1);
+  const request = JSON.parse(sipClient.requests[0].body).request;
+  const emitResult = (
+    callId: string,
+    reqid: number,
+    command: string,
+    code: number,
+  ) => {
+    sipClient.emit(
+      "inboundMessage",
+      new InboundMessage(
+        "INFO sip:100@example.com SIP/2.0",
+        { CSeq: "2 INFO", "Call-Id": callId },
+        JSON.stringify({
+          response: {
+            reqid,
+            command,
+            result: { code, description: String(code) },
+          },
+        }),
+      ),
+    );
+  };
+  emitResult("other-call", request.reqid, request.command, 1);
+  emitResult(session.callId, request.reqid + 1, request.command, 2);
+  emitResult(session.callId, request.reqid, "stopcallrecord", 3);
+  emitResult(session.callId, request.reqid, request.command, 0);
+
+  await expect(resultPromise).resolves.toEqual({ code: 0, description: "0" });
+});
+
+test("completes and times out transfers on the Call Session", async () => {
+  const sipClient = new FakeSipClient();
+  const webPhone = new WebPhone({ sipInfo, sipClient });
+  const session = new InboundCallSession(webPhone, inboundInvite());
+  webPhone.callSessions.push(session);
+  let completed = false;
+  const transfer = session.transfer("102", 100).then(() => {
+    completed = true;
+  });
+  await expect.poll(() => sipClient.requests).toHaveLength(1);
+  sipClient.emit(
+    "inboundMessage",
+    new InboundMessage("BYE sip:100@example.com SIP/2.0", {
+      CSeq: "2 BYE",
+      "Call-Id": "other-call",
+    }),
+  );
+  await new Promise((resolve) => setTimeout(resolve));
+  expect(completed).toBe(false);
+  sipClient.emit(
+    "inboundMessage",
+    new InboundMessage("BYE sip:100@example.com SIP/2.0", {
+      CSeq: "3 BYE",
+      "Call-Id": session.callId,
+    }),
+  );
+  await transfer;
+  expect(session.state).toBe("disposed");
+  expect(webPhone.callSessions).toEqual([]);
+
+  const timedOut = new InboundCallSession(
+    webPhone,
+    inboundInvite(REMOTE_OFFER, "timeout-call"),
+  );
+  webPhone.callSessions.push(timedOut);
+  await expect(timedOut.transfer("102", 1)).rejects.toThrow("timed out");
+});
+
+test("completes inbound forward on the Call Session CANCEL", async () => {
+  const sipClient = new FakeSipClient();
+  const webPhone = new WebPhone({ sipInfo, sipClient });
+  const session = new InboundCallSession(webPhone, inboundInvite());
+  webPhone.callSessions.push(session);
+  let completed = false;
+  const forward = session.forward("102").then(() => {
+    completed = true;
+  });
+  await expect.poll(() => sipClient.requests).toHaveLength(1);
+  sipClient.emit(
+    "inboundMessage",
+    new InboundMessage("CANCEL sip:100@example.com SIP/2.0", {
+      CSeq: "2 CANCEL",
+      "Call-Id": "other-call",
+    }),
+  );
+  await new Promise((resolve) => setTimeout(resolve));
+  expect(completed).toBe(false);
+  sipClient.emit(
+    "inboundMessage",
+    new InboundMessage("CANCEL sip:100@example.com SIP/2.0", {
+      CSeq: "3 CANCEL",
+      "Call-Id": session.callId,
+    }),
+  );
+  await forward;
+  expect(session.state).toBe("disposed");
+  expect(webPhone.callSessions).toEqual([]);
+});
+
+test("reports an outbound final-response failure on the Call Session", async () => {
+  const sipClient = new FakeSipClient();
+  sipClient.requestHandler = async (message) => {
+    if (!message.headers["Proxy-Authorization"]) {
+      return new InboundMessage("SIP/2.0 407 Proxy Authentication Required", {
+        "Proxy-Authenticate": 'Digest, nonce="nonce"',
+      });
+    }
+    const progress = new InboundMessage("SIP/2.0 183 Session Progress", {
+      Via: message.headers.Via,
+      CSeq: message.headers.CSeq,
+      From: message.headers.From,
+      To: `${message.headers.To};tag=remote`,
+      "Call-Id": message.headers["Call-Id"],
+    });
+    setTimeout(() => {
+      sipClient.emit(
+        "inboundMessage",
+        new InboundMessage("SIP/2.0 486 Busy Here", {
+          CSeq: progress.headers.CSeq,
+          "Call-Id": message.headers["Call-Id"],
+        }),
+      );
+    });
+    return progress;
+  };
+  const webPhone = new WebPhone({
+    sipInfo,
+    sipClient,
+    webRtcSessionFactory: () => new FakeWebRtcSession(),
+  });
+
+  const session = await webPhone.call("invalid");
+
+  expect(session.state).toBe("disposed");
+  expect(webPhone.callSessions).toEqual([]);
 });
 
 test("keeps hold SDP policy in CallSession", async () => {

--- a/test/web-rtc-session.spec.ts
+++ b/test/web-rtc-session.spec.ts
@@ -186,12 +186,12 @@ test("projects inbound SIP messages onto the matching live Call Session", async 
 
   const bye = new InboundMessage("BYE sip:100@example.com SIP/2.0", {
     CSeq: "6 BYE",
-    "Call-Id": callId,
+    "Call-ID": callId,
   });
   sipClient.emit("inboundMessage", bye);
   expect(scopedMessages.at(-1)).toBe(bye);
   expect(scopedMessages).toHaveLength(4);
-  expect(webPhone.callSessions).toEqual([]);
+  expect(webPhone.callSessions).toHaveLength(0);
 
   sipClient.emit(
     "inboundMessage",
@@ -467,7 +467,7 @@ test("reports an outbound final-response failure on the Call Session", async () 
         "inboundMessage",
         new InboundMessage("SIP/2.0 486 Busy Here", {
           CSeq: progress.headers.CSeq,
-          "Call-Id": message.headers["Call-Id"],
+          "call-id": message.headers["Call-Id"],
         }),
       );
     });
@@ -482,7 +482,7 @@ test("reports an outbound final-response failure on the Call Session", async () 
   const session = await webPhone.call("invalid");
 
   expect(session.state).toBe("disposed");
-  expect(webPhone.callSessions).toEqual([]);
+  expect(webPhone.callSessions).toHaveLength(0);
 });
 
 test("keeps hold SDP policy in CallSession", async () => {

--- a/test/web-rtc-session.spec.ts
+++ b/test/web-rtc-session.spec.ts
@@ -330,13 +330,6 @@ test("delegates inbound offer and offerless call negotiation", async () => {
   expect(offerlessWebRtc.offers).toEqual([{ iceRestart: true }]);
   expect(offerlessWebRtc.appliedAnswers).toEqual([NORMALIZED_REMOTE_ANSWER]);
   sipClient.emit("inboundMessage", alreadyProcessedMessage("other-call"));
-  let completed = false;
-  void offerlessAnswer.then(() => {
-    completed = true;
-  });
-  await new Promise((resolve) => setTimeout(resolve));
-  expect(completed).toBe(false);
-  sipClient.emit("inboundMessage", alreadyProcessedMessage("offerless-call"));
   await offerlessAnswer;
 });
 


### PR DESCRIPTION
## Summary
- Add the central Call-ID-scoped Call Session inboundMessage projection while preserving the global SIP Client feed.
- Move call-specific workflows to the scoped event where the SIP message belongs to the Call Session.
- Keep RingCentral answer and reply control messages global where observed Call-IDs differ: answer no longer waits for AlreadyProcessed, and reply correlates SessionClose by RingCentral SID.
- Update event documentation and public-behavior regression coverage.

## Scope
Parent: #416
Children: #417 and #418

## Verification
- Combined Spec review: 0 findings
- Combined Standards review: 0 hard violations, 0 smells
- pnpm test: 36 passed